### PR TITLE
Add code to generate options in 'table-editable.js' to match RECORDS_…

### DIFF
--- a/app/static/admin/pages/scripts/table-editable.js
+++ b/app/static/admin/pages/scripts/table-editable.js
@@ -22,9 +22,14 @@ var TableEditable = function () {
         function editRow(oTable, nRow) {
             var aData = oTable.fnGetData(nRow);
             var jqTds = $('>td', nRow);
+	    var record_types = "";
+	    for(var i = 0; i < records_allow_edit.length; i++) {
+               var record_type = records_allow_edit[i];
+               record_types += "<option value=\"" + record_type + "\">" + record_type + "</option>";
+            }
             jqTds[0].innerHTML = '<input type="text" class="form-control input-small" value="' + aData[0] + '">';
             //jqTds[1].innerHTML = '<select class="form-control" id="record_type" name="record_type" value="' + aData[1]  + '"' + '><option value="A">A</option><option value="AAAA">AAAA</option><option value="NS">NS</option><option value="CNAME">CNAME</option><option value="DNAME">DNAME</option><option value="MR">MR</option><option value="PTR">PTR</option><option value="HINFO">HINFO</option><option value="MX">MX</option><option value="TXT">TXT</option><option value="RP">RP</option><option value="AFSDB">AFSDB</option><option value="SIG">SIG</option><option value="KEY">KEY</option><option value="LOC">LOC</option><option value="SRV">SRV</option><option value="CERT">CERT</option><option value="NAPTR">NAPTR</option><option value="DS">DS</option><option value="SSHFP">SSHFP</option><option value="RRSIG">RRSIG</option><option value="NSEC">NSEC</option><option value="DNSKEY">DNSKEY</option><option value="NSEC3">DSEC3</option><option value="NSEC3PARAM">NSEC3PARAM</option><option value="TLSA">TLSA</option><option value="SPF">SPF</option><option value="DL">DL</option><option value="SOA">SOA</option></select>';
-            jqTds[1].innerHTML = '<select class="form-control" id="record_type" name="record_type" value="' + aData[1]  + '"' + '><option value="A">A</option><option value="AAAA">AAAA</option><option value="CNAME">CNAME</option><option value="PTR">PTR</option><option value="MX">MX</option><option value="TXT">TXT</option><option value="SPF">SPF</option></select>';
+            jqTds[1].innerHTML = '<select class="form-control" id="record_type" name="record_type" value="' + aData[1]  + '"' + '>' + record_types + '</select>';
             jqTds[2].innerHTML = '<select class="form-control" id="record_status" name="record_status" value="' + aData[2]  + '"' + '><option value="false">Active</option><option value="true">Disabled</option></select>';
             jqTds[3].innerHTML = '<select class="form-control" id="record_ttl" name="record_ttl" value="' + aData[3]  + '"' + '><option value="60">1 minute</option><option value="300">5 minutes</option><option value="1800">30 minutes</option><option value="3600">60 minutes</option><option value="86400">24 hours</option></select>';
             jqTds[4].innerHTML = '<input type="text" class="form-control input-small advance-data" value="' + aData[4] + '">';

--- a/app/templates/domain.html
+++ b/app/templates/domain.html
@@ -185,7 +185,8 @@
 <script src="{{ url_for('static', filename='admin/pages/scripts/table-editable.js') }}"></script>
 <!-- END TABLE PLUGINS -->
 <script>
-jQuery(document).ready(function() {    
+jQuery(document).ready(function() {
+   window.records_allow_edit = {{ editable_records|tojson }};
    Metronic.init(); // init metronic core componets
    Layout.init(); // init layout
    TableEditable.init();

--- a/app/views.py
+++ b/app/views.py
@@ -146,7 +146,7 @@ def domain(domain_name):
             if jr['type'] in app.config['RECORDS_ALLOW_EDIT']:
                 record = Record(name=jr['name'], type=jr['type'], status='Disabled' if jr['disabled'] else 'Active', ttl=jr['ttl'], data=jr['content'])
                 records.append(record)
-        return render_template('domain.html', domain=domain, records=records)
+        return render_template('domain.html', domain=domain, records=records, editable_records=app.config['RECORDS_ALLOW_EDIT'])
     else:
         return redirect(url_for('error', code=404))
 

--- a/config_template.py
+++ b/config_template.py
@@ -29,5 +29,4 @@ PDNS_STATS_URL = 'http://172.16.214.131:8081/'
 PDNS_API_KEY = 'you never know'
 
 # RECORDS ALLOWED TO EDIT
-# If you change these values, please change in ./static/admin/pages/scripts/table-editable.js also
 RECORDS_ALLOW_EDIT = ['A', 'AAAA', 'CNAME', 'SPF', 'PTR', 'MX', 'TXT']


### PR DESCRIPTION
…ALLOW_EDIT in the config.py file.

This change removes the need for a user to manually edit the template files when adding or removing allowed-to-edit record types. Please review and comment.