### PR TITLE
Fixes issue #11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,21 +58,6 @@ Create database after having proper configs
 (flask)% ./createdb.py
 ```
 
-Manually add some data into our `powerdnsadmin` database
-```
-$ mysql
-
-MariaDB [(none)]> use powerdnsadmin;
-
-MariaDB [powerdnsadmin]> INSERT INTO role(name, description) VALUES ('Administrator', 'Administrator');
-Query OK, 1 row affected (0.00 sec)
-
-MariaDB [powerdnsadmin]> INSERT INTO role(name, description) VALUES ('User', 'User');
-Query OK, 1 row affected (0.01 sec)
-
-MariaDB [powerdnsadmin]> INSERT INTO setting(name, value) VALUES('maintenance', 'False');
-Query OK, 1 row affected (0.00 sec)
-```
 
 Run the application and enjoy!
 ```

--- a/app/models.py
+++ b/app/models.py
@@ -187,9 +187,9 @@ class User(db.Model):
 
                         # first register user will be in Administrator role
                         if User.query.count() == 0:
-                            self.role_id = 1
+                            self.role_id = Role.query.filter_by(name='Administrator').first().id
                         else:
-                            self.role_id = 2
+                            self.role_id = Role.query.filter_by(name='User').first().id    
 
                         self.create_user()
                         logging.info('Created user "%s" in the DB' % self.username)
@@ -230,9 +230,9 @@ class User(db.Model):
         try:
             # first register user will be in Administrator role
             if User.query.count() == 0:
-                self.role_id = 1
+                self.role_id = Role.query.filter_by(name='Administrator').first().id
             else:
-                self.role_id = 2
+                self.role_id = Role.query.filter_by(name='User').first().id
 
             user = User(username=self.username, firstname=self.firstname, lastname=self.lastname, role_id=self.role_id, email=self.email, password=self.get_hashed_password(self.plain_text_password))
             db.session.add(user)
@@ -340,8 +340,14 @@ class Role(db.Model):
     description = db.Column(db.String(128))
     users = db.relationship('User', backref='role', lazy='dynamic')
 
-    def __int__(self, id=None, name=None, description=None):
+    def __init__(self, id=None, name=None, description=None):
         self.id = id
+        self.name = name
+        self.description = description
+        
+    # allow database autoincrement to do its own ID assignments    
+    def __init__(self, name=None, description=None):
+        self.id = None
         self.name = name
         self.description = description
 
@@ -910,6 +916,12 @@ class Setting(db.Model):
         self.id = id
         self.name = name
         self.value = value
+        
+    # allow database autoincrement to do its own ID assignments
+    def __init__(self, name=None, value=None):
+        self.id = None
+        self.name = name
+        self.value = value    
 
     def set_mainteance(self, mode):
         """

--- a/create_db.py
+++ b/create_db.py
@@ -3,8 +3,17 @@ from migrate.versioning import api
 from config import SQLALCHEMY_DATABASE_URI
 from config import SQLALCHEMY_MIGRATE_REPO
 from app import db
+from app.models import Role, Setting
 import os.path
 db.create_all()
+# create initial user roles and turn off maintenance mode
+admin_role = Role('Administrator', 'Administrator')
+user_role = Role('User', 'User')
+maintenance_setting = Setting('maintenance', 'False')
+db.session.add(admin_role)
+db.session.add(user_role)
+db.session.add(maintenance_setting)
+db.session.commit()
 if not os.path.exists(SQLALCHEMY_MIGRATE_REPO):
     api.create(SQLALCHEMY_MIGRATE_REPO, 'database repository')
     api.version_control(SQLALCHEMY_DATABASE_URI, SQLALCHEMY_MIGRATE_REPO)


### PR DESCRIPTION
This change populates the 'role' and 'setting' tables to their initial
states via the create_db.py script which removes a step from the initial
setup. We now also search for roles instead of expecting them to be at
certain IDs.