### PR TITLE
Change record manage table to use monospaced font.

### DIFF
--- a/app/static/admin/layout2/css/custom.css
+++ b/app/static/admin/layout2/css/custom.css
@@ -1,5 +1,9 @@
 /* here you can put your own css to customize and override the theme */
 
+#tbl_record_manage td {
+	font-family:'Roboto Mono' !important;
+}
+
 /***
 Rounded Portlets
 ***/

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,6 +13,7 @@
 
         <!-- BEGIN GLOBAL MANDATORY STYLES -->
         <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700&subset=all" rel="stylesheet" type="text/css"/>
+        <link href='http://fonts.googleapis.com/css?family=Roboto+Mono:400,300,700' rel='stylesheet' type='text/css'>
         <link href="{{ url_for('static', filename='global/plugins/font-awesome/css/font-awesome.min.css') }}" rel="stylesheet" type="text/css"/>
         <link href="{{ url_for('static', filename='global/plugins/simple-line-icons/simple-line-icons.min.css') }}" rel="stylesheet" type="text/css"/>
         <link href="{{ url_for('static', filename='global/plugins/bootstrap/css/bootstrap.min.css') }}" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Change font in editable table to 'Roboto Mono' from 'Open Sans' to improve readability. Both fonts are available via the Google Fonts service.