### PR TITLE
Regarding Issue #62 - Fix to provide client IP

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -658,7 +658,7 @@ def qrcode():
 @app.route('/nic/checkip.html', methods=['GET', 'POST'])
 def dyndns_checkip():
     # route covers the default ddclient 'web' setting for the checkip service
-    return render_template('dyndns.html', response=request.headers.get('X-Real-IP'))
+    return render_template('dyndns.html', response=request.environ.get('REMOTE_ADDR'))
 
 @app.route('/nic/update', methods=['GET', 'POST'])
 @dyndns_login_required


### PR DESCRIPTION
use request.environ.get instead of request.headers.get