### PR TITLE
Replace direct 'click' event binding with delegated binding. Fixes #58.

### DIFF
--- a/app/templates/admin_history.html
+++ b/app/templates/admin_history.html
@@ -71,8 +71,7 @@
         "info" : true,
         "autoWidth" : false
     });
-
-    $(".history-info-button").click(function() {
+    $(document.body).on('click', '.history-info-button', function() {
         var modal = $("#modal_history_info");
         var info = $(this).val();
         modal.find('.modal-body p').text(info);

--- a/app/templates/admin_manageuser.html
+++ b/app/templates/admin_manageuser.html
@@ -84,7 +84,7 @@
     });
     
     // handle revocation of privileges
-    $('.button_revoke').click(function() {
+    $(document.body).on('click', '.button_revoke', function() {
         var modal = $("#modal_revoke");
         var username = $(this).prop('id');
         var info = "Are you sure you want to revoke all privileges for " + username + ". They will not able to access any domain."; 
@@ -97,7 +97,7 @@
         modal.modal('show');
     });
     // handle deletion of user
-    $('.button_delete').click(function() {
+    $(document.body).on('click', '.button_delete', function() {
         var modal = $("#modal_delete");
         var username = $(this).prop('id');
         var info = "Are you sure you want to delete " + username + "?"; 
@@ -118,7 +118,7 @@
     });
     
     // handle checkbox toggling
-    $('.admin_toggle').on('ifToggled', function(event) {
+    $(document.body).on('ifToggled', '.admin_toggle', function() {
         var is_admin = $(this).prop('checked');
         var username = $(this).prop('id');
         postdata = {

--- a/app/templates/admin_settings.html
+++ b/app/templates/admin_settings.html
@@ -74,13 +74,12 @@
         "info" : true,
         "autoWidth" : false
     });
-
-    $(".setting-toggle-button").click(function() {
+    $(document.body).on('click', '.setting-toggle-button', function() {
         var setting = $(this).prop('id');
         applyChanges('','/admin/setting/' + setting + '/toggle', false, true)
     });
     
-    $(".setting-save-button").click(function() {
+    $(document.body).on('click', '.setting-save-button', function() {
         var setting = $(this).prop('id');
         var value = $(this).parents('tr').find('#value')[0].value;
         var postdata = {'value': value};

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -223,14 +223,13 @@
         "info" : false,
         "autoWidth" : false
     });
-
-    $(".history-info-button").click(function() {
+    $(document.body).on('click', '.history-info-button', function() {
         var modal = $("#modal_history_info");
         var info = $(this).val();
         modal.find('.modal-body p').text(info);
         modal.modal('show');
     });
-    $(document).on("click", ".button_dnssec", function() {
+    $(document.body).on("click", ".button_dnssec", function() {
         var domain = $(this).prop('id');
         getdnssec('/domain/' + domain + '/dnssec');
     });

--- a/app/templates/domain.html
+++ b/app/templates/domain.html
@@ -147,7 +147,7 @@
     });
     
     // handle delete button
-    $(document).on("click", ".button_delete", function(e) {
+    $(document.body).on("click", ".button_delete", function(e) {
         e.stopPropagation();
         var modal = $("#modal_delete");
         var table = $("#tbl_records").DataTable();
@@ -163,7 +163,7 @@
         
     });
     // handle edit button
-    $(document).on("click", ".button_edit, .row_record", function(e) {
+    $(document.body).on("click", ".button_edit, .row_record", function(e) {
          e.stopPropagation();
          if ($(this).is('tr')) {
             var nRow = $(this)[0]; 
@@ -193,7 +193,7 @@
     });
     
     // handle apply changes button
-    $(document).on("click",".button_apply_changes", function() {
+    $(document.body).on("click",".button_apply_changes", function() {
         var modal = $("#modal_apply_changes");
         var table = $("#tbl_records").DataTable();
         var domain = $(this).prop('id');
@@ -209,7 +209,7 @@
     });
     
     // handle add record button
-    $(document).on("click", ".button_add_record", function (e) {
+    $(document.body).on("click", ".button_add_record", function (e) {
             if (nNew || nEditing) {
                 // TODO: replace this alert with modal
                 alert("Previous record not saved. Please save it before adding more record.")
@@ -225,7 +225,7 @@
         });
     
     //handle cancel button
-    $(document).on("click", ".button_cancel", function (e) {
+    $(document.body).on("click", ".button_cancel", function (e) {
             e.stopPropagation();
             var oTable = $("#tbl_records").DataTable();
             if (nNew) {
@@ -239,7 +239,7 @@
         });
     
     //handle save button
-    $(document).on("click", ".button_save", function (e) {
+    $(document.body).on("click", ".button_save", function (e) {
             e.stopPropagation();
             var table = $("#tbl_records").DataTable();
             saveRow(table, nEditing);
@@ -248,14 +248,14 @@
         });
     
     //handle update_from_master button
-    $(document).on("click", ".button_update_from_master", function (e) {
+    $(document.body).on("click", ".button_update_from_master", function (e) {
             var domain = $(this).prop('id');
             applyChanges({'domain': domain}, '/domain/' + domain + '/update');
     });
     
     {% if record_helper_setting %}
     //handle wacky record types
-    $(document).on("focus", "#current_edit_record_data", function (e) {
+    $(document.body).on("focus", "#current_edit_record_data", function (e) {
         var record_type = $(this).parents("tr").find('#record_type').val();
         var record_data = $(this);
         if (record_type == "MX") {

--- a/app/templates/domain_management.html
+++ b/app/templates/domain_management.html
@@ -77,7 +77,7 @@
 $("#domain_multi_user").multiSelect();
 
 // handle deletion of user
-$('.delete_domain').click(function() {
+$(document.body).on('click', '.delete_domain', function() {
     var modal = $("#modal_delete_domain");
     var domain = $(this).prop('id');
     var info = "Are you sure you want to delete " + domain + "?";


### PR DESCRIPTION
Direct binding only works for elements already in the DOM, delegated
binding works for all elements that match a filter even if created after
the DOM is fully loaded.

This fixes all click events that have may be created dynamically (when DataTables change pages or sort settings, etc)