### PR TITLE
Fix route when the zone name containing slash character.

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -256,7 +256,7 @@ def dashboard():
     return render_template('dashboard.html', domains=domains, domain_count=domain_count, users=users, history_number=history_number, uptime=uptime, histories=history)
 
 
-@app.route('/domain/<string:domain_name>', methods=['GET', 'POST'])
+@app.route('/domain/<path:domain_name>', methods=['GET', 'POST'])
 @app.route('/domain', methods=['GET', 'POST'])
 @login_required
 def domain(domain_name):


### PR DESCRIPTION
We delagate many sub zones and foward zones so in our database containing slash charater in the revers zone names. Whitout this fix I give back 404 error page.