### PR TITLE
Users could use SQLite instead of MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ This will enable API access in PowerDNS so PowerDNS-Admin can intergrate with Po
 
 ### Create Database
 We will create a database which used by this web application. Please note that this database is difference from pdns database itself.
+
+You could use any database that SQLAlchemy supports. For example MySQL (you will need to `pip install MySQL-python` to use MySQL backend):
 ```
 MariaDB [(none)]> CREATE DATABASE powerdnsadmin;
 
 MariaDB [(none)]> GRANT ALL PRIVILEGES ON powerdnsadmin.* TO powerdnsadmin@'%' IDENTIFIED BY 'your-password';
 ```
+For testing purpose, you could also use SQLite as backend. This way you do not have to install `MySQL-python` dependency.
+
 
 ### PowerDNS-Admin
 

--- a/config_template.py
+++ b/config_template.py
@@ -11,7 +11,7 @@ LOGIN_TITLE = "PDNS"
 # TIMEOUT - for large zones
 TIMEOUT = 10
 
-# LOG CONFIG 
+# LOG CONFIG
 LOG_LEVEL = 'DEBUG'
 LOG_FILE = 'logfile.log'
 
@@ -19,12 +19,13 @@ LOG_FILE = 'logfile.log'
 UPLOAD_DIR = os.path.join(basedir, 'upload')
 
 # DATABASE CONFIG
-SQLALCHEMY_DATABASE_URI = 'mysql://root:123456@192.168.59.103/pdns'
+SQLALCHEMY_DATABASE_URI = 'mysql://root:123456@192.168.59.103/pdns'  # You'll need MySQL-python
+#SQLALCHEMY_DATABASE_URI = 'sqlite:////path/to/your/pdns.db'
 SQLALCHEMY_MIGRATE_REPO = os.path.join(basedir, 'db_repository')
 SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 # LDAP CONFIG
-LDAP_TYPE = 'ldap' # use 'ad' for MS Active Directory
+LDAP_TYPE = 'ldap'  # use 'ad' for MS Active Directory
 LDAP_URI = 'ldaps://your-ldap-server:636'
 LDAP_USERNAME = 'cn=dnsuser,ou=users,ou=services,dc=duykhanh,dc=me'
 LDAP_PASSWORD = 'dnsuser'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Flask>=0.10
 Flask-WTF>=0.11
 Flask-Login>=0.2.11
 configobj==5.0.5
-MySQL-python==1.2.5
 py-bcrypt==0.4
 requests==2.7.0
 python-ldap==2.4.21


### PR DESCRIPTION
PowerDNS-Admin uses SQLAlchemy as ORM, which supports various database backends. `MySQL-python` should not be listed as a must-have depenedency in `requirements.txt` since it needs compiling and complex setup. For testing purpose, users could use SQLite, which is a built-in function in most Python distributions.

This PR removes `MySQL-python` dependency and instructs users to try SQLite if they do not want to install MySQL / MySQL-python.

My tests show that PowerDNS-Admin works perfectly with SQLite backend.