### PR TITLE
Allow to change root domain record via dyndns

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -762,12 +762,12 @@ def dyndns_update():
     domain = None
     domain_segments = hostname.split('.')
     for index in range(len(domain_segments)):
-        domain_segments.pop(0)
         full_domain = '.'.join(domain_segments)
         potential_domain = Domain.query.filter(Domain.name == full_domain).first()
         if potential_domain in domains:
             domain = potential_domain
             break
+        domain_segments.pop(0)
 
     if not domain:
         history = History(msg="DynDNS update: attempted update of %s but it does not exist for this user" % hostname, created_by=current_user.username)


### PR DESCRIPTION
It was not possible to update `example.com`. only `foo.example.com`
