### PR TITLE
Log to file only if the file exists

### DIFF
--- a/app/lib/log.py
+++ b/app/lib/log.py
@@ -27,18 +27,21 @@ class logger(object):
         # set request requests module log level
         logging.getLogger("requests").setLevel(logging.CRITICAL)
 
-        # define handler to log into file
-        file_log_handler = logging.FileHandler(self.logfile)
-        logger.addHandler(file_log_handler)
+        if self.logfile and os.path.isfile(self.logfile):
+            # define handler to log into file
+            file_log_handler = logging.FileHandler(self.logfile)
+            logger.addHandler(file_log_handler)
+
+            # define logging format for file
+            file_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            file_log_handler.setFormatter(file_formatter)
 
         # define handler to log into console
         stderr_log_handler = logging.StreamHandler()
         logger.addHandler(stderr_log_handler)
 
-        # define logging format for file and console
-        file_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        # define logging format for console
         console_formatter = logging.Formatter('[%(levelname)s] %(message)s')
-        file_log_handler.setFormatter(file_formatter)
         stderr_log_handler.setFormatter(console_formatter)
 
         return logging.getLogger(self.name)

--- a/app/lib/log.py
+++ b/app/lib/log.py
@@ -27,7 +27,7 @@ class logger(object):
         # set request requests module log level
         logging.getLogger("requests").setLevel(logging.CRITICAL)
 
-        if self.logfile and os.path.isfile(self.logfile):
+        if self.logfile:
             # define handler to log into file
             file_log_handler = logging.FileHandler(self.logfile)
             logger.addHandler(file_log_handler)

--- a/config_template.py
+++ b/config_template.py
@@ -14,8 +14,8 @@ TIMEOUT = 10
 # LOG CONFIG
 LOG_LEVEL = 'DEBUG'
 LOG_FILE = 'logfile.log'
-# For Docker, set the following
-#LOG_FILE = '/dev/stdout'
+# For Docker, leave empty string
+#LOG_FILE = ''
 
 # Upload
 UPLOAD_DIR = os.path.join(basedir, 'upload')


### PR DESCRIPTION
If LOG_FILE config option contained invalid file, pdns admin wouldn't start.
Also, it wasn't possible to log only to stdout/stderr correctly, because
setting the log file to /dev/stdout would double the logs messages as the pdns
admin is already logging to the stderr.