### PR TITLE
Fix issue #133. Store hash as '*' for external users

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -242,6 +242,10 @@ class User(db.Model):
         We will create a local user (in DB) in order to manage user
         profile such as name, roles,...
         """
+        
+        # Set an invalid password hash for non local users
+        self.password = '*'
+        
         db.session.add(self)
         db.session.commit()
 


### PR DESCRIPTION
Set password to '*' for users created by the create_user method. Should cause an invalid password hash for non local users added to the database
