### PR TITLE
Feature/automatic reverse domain creation

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1044,8 +1044,10 @@ class Record(object):
         domain_obj = Domain.query.filter(Domain.name == domain).first()
         domain_auto_ptr = DomainSetting.query.filter(DomainSetting.domain == domain_obj).filter(DomainSetting.setting == 'auto_ptr').first()
         domain_auto_ptr = strtobool(domain_auto_ptr.value) if domain_auto_ptr else False
+
         system_auto_ptr = Setting.query.filter(Setting.name == 'auto_ptr').first()
         system_auto_ptr = strtobool(system_auto_ptr.value)
+        
         if system_auto_ptr or domain_auto_ptr:
             try:
                 d = Domain()
@@ -1053,7 +1055,7 @@ class Record(object):
                     if r['type'] in ['A', 'AAAA']:
                         r_name = r['name'] + '.'
                         r_content = r['content']
-                        temp = re.search('^(([a-f0-9]\.){4}(?P<ipv6name>.+6.arpa)\.?)|(\.(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
+                        temp = re.search('^((([a-f0-9]\.){4})(?P<ipv6name>.+6.arpa)\.?)|((([0-9]+\.){1})(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
                         domain_reverse_name = temp.group('ipv6name') if temp.group('ipv6name') != None else temp.group('ipv4name')  
                         d.create_reverse_domain(domain, domain_reverse_name)
                         self.name = dns.reversename.from_address(r_content).to_text().rstrip('.')
@@ -1066,7 +1068,7 @@ class Record(object):
                     if r['type'] in ['A', 'AAAA']:
                         r_name = r['name'] + '.'
                         r_content = r['content']
-                        temp = re.search('^(([a-f0-9]\.){4}(?P<ipv6name>.+6.arpa)\.?)|(\.(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
+                        temp = re.search('^((([a-f0-9]\.){4})(?P<ipv6name>.+6.arpa)\.?)|((([0-9]+\.){1})(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
                         domain_reverse_name = temp.group('ipv6name') if temp.group('ipv6name') != None else temp.group('ipv4name')  
                         self.name = dns.reversename.from_address(r_content).to_text()
                         self.type = 'PTR'

--- a/app/models.py
+++ b/app/models.py
@@ -610,7 +610,7 @@ class Domain(db.Model):
         Check the existing reverse lookup domain, 
         if not exists create a new one automatically
         """
-        domain_obj = Domain.query.filter(Domain.name == domain).first()
+        domain_obj = Domain.query.filter(Domain.name == domain_name).first()
         domain_auto_ptr = DomainSetting.query.filter(DomainSetting.domain == domain_obj).filter(DomainSetting.setting == 'auto_ptr').first()
         domain_auto_ptr = strtobool(domain_auto_ptr.value) if domain_auto_ptr else False
         system_auto_ptr = Setting.query.filter(Setting.name == 'auto_ptr').first()

--- a/app/models.py
+++ b/app/models.py
@@ -1060,7 +1060,7 @@ class Record(object):
 
         system_auto_ptr = Setting.query.filter(Setting.name == 'auto_ptr').first()
         system_auto_ptr = strtobool(system_auto_ptr.value)
-        
+
         if system_auto_ptr or domain_auto_ptr:
             try:
                 d = Domain()
@@ -1068,8 +1068,8 @@ class Record(object):
                     if r['type'] in ['A', 'AAAA']:
                         r_name = r['name'] + '.'
                         r_content = r['content']
-                        temp = re.search('^((([a-f0-9]\.){4})(?P<ipv6name>.+6.arpa)\.?)|((([0-9]+\.){1})(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
-                        domain_reverse_name = temp.group('ipv6name') if temp.group('ipv6name') != None else temp.group('ipv4name')  
+                        reverse_host_address = dns.reversename.from_address(r_content).to_text()
+                        domain_reverse_name = d.get_reverse_domain_name(reverse_host_address)
                         d.create_reverse_domain(domain, domain_reverse_name)
                         self.name = dns.reversename.from_address(r_content).to_text().rstrip('.')
                         self.type = 'PTR'
@@ -1081,9 +1081,9 @@ class Record(object):
                     if r['type'] in ['A', 'AAAA']:
                         r_name = r['name'] + '.'
                         r_content = r['content']
-                        temp = re.search('^((([a-f0-9]\.){4})(?P<ipv6name>.+6.arpa)\.?)|((([0-9]+\.){1})(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
-                        domain_reverse_name = temp.group('ipv6name') if temp.group('ipv6name') != None else temp.group('ipv4name')  
-                        self.name = dns.reversename.from_address(r_content).to_text()
+                        reverse_host_address = dns.reversename.from_address(r_content).to_text()
+                        domain_reverse_name = d.get_reverse_domain_name(reverse_host_address)
+                        self.name = reverse_host_address
                         self.type = 'PTR'
                         self.data = r_content
                         self.delete(domain_reverse_name)

--- a/app/models.py
+++ b/app/models.py
@@ -797,7 +797,7 @@ class Record(object):
         if NEW_SCHEMA:
             data = {"rrsets": [
                         {
-                            "name": self.name + '.',
+                            "name": self.name.rstrip('.') + '.',
                             "type": self.type,
                             "changetype": "REPLACE",
                             "ttl": self.ttl,
@@ -889,7 +889,7 @@ class Record(object):
 
         records = []
         for r in deleted_records:
-            r_name = r['name'] + '.' if NEW_SCHEMA else r['name']
+            r_name = r['name'].rstrip('.') + '.' if NEW_SCHEMA else r['name']
             r_type = r['type']
             if PRETTY_IPV6_PTR: # only if activated
                 if NEW_SCHEMA: # only if new schema
@@ -911,7 +911,7 @@ class Record(object):
         records = []
         for r in new_records:
             if NEW_SCHEMA:
-                r_name = r['name'] + '.'
+                r_name = r['name'].rstrip('.') + '.'
                 r_type = r['type']
                 if PRETTY_IPV6_PTR: # only if activated
                     if r_type == 'PTR': # only ptr
@@ -1034,7 +1034,7 @@ class Record(object):
                         temp = re.search('^(([a-f0-9]\.){4}(?P<ipv6name>.+6.arpa)\.?)|(\.(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
                         domain_reverse_name = temp.group('ipv6name') if temp.group('ipv6name') != None else temp.group('ipv4name')  
                         d.create_reverse_domain(domain, domain_reverse_name)
-                        self.name = dns.reversename.from_address(r_content).to_text()
+                        self.name = dns.reversename.from_address(r_content).to_text().rstrip('.')
                         self.type = 'PTR'
                         self.status = r['disabled']
                         self.ttl = r['ttl']
@@ -1063,7 +1063,7 @@ class Record(object):
         headers['X-API-Key'] = PDNS_API_KEY
         data = {"rrsets": [
                     {
-                        "name": self.name,
+                        "name": self.name.rstrip('.') + '.',
                         "type": self.type,
                         "changetype": "DELETE",
                         "records": [

--- a/app/models.py
+++ b/app/models.py
@@ -8,6 +8,7 @@ import itertools
 import traceback
 import pyotp
 import re
+import dns.reversename
 
 from datetime import datetime
 from distutils.version import StrictVersion
@@ -32,7 +33,6 @@ else:
 if 'PRETTY_IPV6_PTR' in app.config.keys():
     import dns.inet
     import dns.name
-    import dns.reversename
     PRETTY_IPV6_PTR = app.config['PRETTY_IPV6_PTR']
 else:
     PRETTY_IPV6_PTR = False

--- a/app/models.py
+++ b/app/models.py
@@ -1038,7 +1038,15 @@ class Record(object):
             return {'status': 'error', 'msg': 'There was something wrong, please contact administrator'}
 
     def auto_ptr(self, domain, new_records, deleted_records):
-        if app.config['AUTOMATIC_REVERSE_PTR']:
+        """
+        Add auto-ptr records
+        """
+        domain_obj = Domain.query.filter(Domain.name == domain).first()
+        domain_auto_ptr = DomainSetting.query.filter(DomainSetting.domain == domain_obj).filter(DomainSetting.setting == 'auto_ptr').first()
+        domain_auto_ptr = strtobool(domain_auto_ptr.value) if domain_auto_ptr else False
+        system_auto_ptr = Setting.query.filter(Setting.name == 'auto_ptr').first()
+        system_auto_ptr = strtobool(system_auto_ptr.value)
+        if system_auto_ptr or domain_auto_ptr:
             try:
                 d = Domain()
                 for r in new_records:

--- a/app/models.py
+++ b/app/models.py
@@ -1017,6 +1017,14 @@ class Record(object):
                 return {'status': 'error', 'msg': jdata2['error']}
             else:
                 logging.info('Record was applied successfully.')
+                for r in new_records:
+                    r_name = r['name'] + '.'
+                    if r['type'] in ['A', 'AAAA']:
+                        r_content = r['content']
+                        temp = re.search('^(([a-f0-9]\.){4}(?P<ipv6name>.+6.arpa)\.?)|(\.(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
+                        domain_reverse_name = temp.group('ipv6name') if temp.group('ipv6name') != None else temp.group('ipv4name')
+                        d = Domain()
+                        d.create_reverse_domain(domain, domain_reverse_name)
                 return {'status': 'ok', 'msg': 'Record was applied successfully'}
         except Exception, e:
             logging.error("Cannot apply record changes to domain %s. DETAIL: %s" % (str(e), domain))

--- a/app/models.py
+++ b/app/models.py
@@ -447,7 +447,7 @@ class Domain(db.Model):
             db.session.commit()
             return True
         except Exception, e:
-            logging.error('Can not create settting %s for domain %s. %s' % (setting, self.name, str(e)))
+            logging.error('Can not create setting %s for domain %s. %s' % (setting, self.name, str(e)))
             return False
 
     def get_domains(self):

--- a/app/models.py
+++ b/app/models.py
@@ -609,6 +609,7 @@ class Domain(db.Model):
         domain_id = self.get_id_by_name(domain_reverse_name)
         if None == domain_id and app.config['AUTOMATIC_REVERSE_PTR']:
             result = self.add(domain_reverse_name, 'Master', 'INCEPTION_INCREMENT', '', '')
+            result = self.add(domain_reverse_name, 'Master', 'INCEPTION-INCREMENT', '', '')
             self.update()
             if result['status'] == 'ok':
                 history = History(msg='Add reverse lookup domain %s' % domain_reverse_name, detail=str({'domain_type': 'Master', 'domain_master_ips': ''}), created_by='System')

--- a/app/models.py
+++ b/app/models.py
@@ -1017,14 +1017,20 @@ class Record(object):
                 return {'status': 'error', 'msg': jdata2['error']}
             else:
                 logging.info('Record was applied successfully.')
+                d = Domain()
                 for r in new_records:
-                    r_name = r['name'] + '.'
                     if r['type'] in ['A', 'AAAA']:
+                        r_name = r['name'] + '.'
                         r_content = r['content']
                         temp = re.search('^(([a-f0-9]\.){4}(?P<ipv6name>.+6.arpa)\.?)|(\.(?P<ipv4name>.+r.arpa)\.?)', dns.reversename.from_address(r_content).to_text())
-                        domain_reverse_name = temp.group('ipv6name') if temp.group('ipv6name') != None else temp.group('ipv4name')
-                        d = Domain()
+                        domain_reverse_name = temp.group('ipv6name') if temp.group('ipv6name') != None else temp.group('ipv4name')  
                         d.create_reverse_domain(domain, domain_reverse_name)
+                        self.name = dns.reversename.from_address(r_content).to_text().rstrip('.')
+                        self.type = 'PTR'
+                        self.status = r['disabled']
+                        self.ttl = r['ttl']
+                        self.data = r_name
+                        self.add(domain_reverse_name)
                 return {'status': 'ok', 'msg': 'Record was applied successfully'}
         except Exception, e:
             logging.error("Cannot apply record changes to domain %s. DETAIL: %s" % (str(e), domain))

--- a/app/models.py
+++ b/app/models.py
@@ -644,17 +644,21 @@ class Domain(db.Model):
         return {'status': 'ok', 'msg': 'Reverse lookup domain already exists'}
 
     def get_reverse_domain_name(self, reverse_host_address):
+        c = 1
         if re.search('ip6.arpa', reverse_host_address):
-            for i in range(31,3,-1):
+            for i in range(1,32,1):
                 address = re.search('((([a-f0-9]\.){'+ str(i) +'})(?P<ipname>.+6.arpa)\.?)', reverse_host_address)
                 if None != self.get_id_by_name(address.group('ipname')):
+                    c = i
                     break
+            return re.search('((([a-f0-9]\.){'+ str(c) +'})(?P<ipname>.+6.arpa)\.?)', reverse_host_address).group('ipname')
         else:
-            for i in range(3,0,-1):
+            for i in range(1,4,1):
                 address = re.search('((([0-9]+\.){'+ str(i) +'})(?P<ipname>.+r.arpa)\.?)', reverse_host_address)
                 if None != self.get_id_by_name(address.group('ipname')):
+                    c = i
                     break
-        return address.group('ipname')
+            return re.search('((([0-9]+\.){'+ str(c) +'})(?P<ipname>.+r.arpa)\.?)', reverse_host_address).group('ipname')
 
     def delete(self, domain_name):
         """

--- a/app/models.py
+++ b/app/models.py
@@ -1049,10 +1049,6 @@ class Record(object):
                         "type": self.type,
                         "changetype": "DELETE",
                         "records": [
-                            {
-                                "name": self.name,
-                                "type": self.type
-                            }
                         ]
                     }
                 ]

--- a/app/models.py
+++ b/app/models.py
@@ -477,8 +477,11 @@ class Domain(db.Model):
         """
         Return domain id
         """
-        domain = Domain.query.filter(Domain.name==name).first()
-        return domain.id
+        try:
+            domain = Domain.query.filter(Domain.name==name).first()
+            return domain.id
+        except:
+            return None
 
     def update(self):
         """

--- a/app/models.py
+++ b/app/models.py
@@ -507,6 +507,10 @@ class Domain(db.Model):
                     if domain_user:
                         domain_user.delete()
                         db.session.commit()
+                    domain_setting = DomainSetting.query.filter(DomainSetting.domain_id==domain.id)
+                    if domain_setting:
+                        domain_setting.delete()
+                        db.session.commit()
 
                     # then remove domain
                     Domain.query.filter(Domain.name == d).delete()

--- a/app/models.py
+++ b/app/models.py
@@ -643,6 +643,19 @@ class Domain(db.Model):
             return {'status': 'ok', 'msg': 'New reverse lookup domain created without users'}
         return {'status': 'ok', 'msg': 'Reverse lookup domain already exists'}
 
+    def get_reverse_domain_name(self, reverse_host_address):
+        if re.search('ip6.arpa', reverse_host_address):
+            for i in range(31,3,-1):
+                address = re.search('((([a-f0-9]\.){'+ str(i) +'})(?P<ipname>.+6.arpa)\.?)', reverse_host_address)
+                if None != self.get_id_by_name(address.group('ipname')):
+                    break
+        else:
+            for i in range(3,0,-1):
+                address = re.search('((([0-9]+\.){'+ str(i) +'})(?P<ipname>.+r.arpa)\.?)', reverse_host_address)
+                if None != self.get_id_by_name(address.group('ipname')):
+                    break
+        return address.group('ipname')
+
     def delete(self, domain_name):
         """
         Delete a single domain name from powerdns

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -168,7 +168,7 @@
                     {{ domain.type }}
                   </td>
                   <td>
-                    {{ domain.serial }}
+                  {% if domain.serial == 0 %}{{ domain.notified_serial }}{% else %}{{domain.serial}}{% endif %}
                   </td>
                   <td>
                     {% if domain.master == '[]'%}N/A {% else %}{{ domain.master|display_master_name }}{% endif %}

--- a/app/templates/domain.html
+++ b/app/templates/domain.html
@@ -223,7 +223,8 @@
             $("#tbl_records").DataTable().search('').columns().search('').draw();
             
             // add new row
-            var nRow = jQuery('#tbl_records').dataTable().fnAddData(['', 'A', 'Active', 3600, '', '', '', '0']);
+            var default_type = records_allow_edit[0]
+            var nRow = jQuery('#tbl_records').dataTable().fnAddData(['', default_type, 'Active', 3600, '', '', '', '0']);
             editRow($("#tbl_records").DataTable(), nRow);
             document.getElementById("edit-row-focus").focus();
             nEditing = nRow;

--- a/app/templates/domain.html
+++ b/app/templates/domain.html
@@ -268,16 +268,16 @@
             var modal = $("#modal_custom_record");
             if (record_data.val() == "") {
                 var form = "    <label for=\"mx_priority\">MX Priority</label> \
-                                <input type=\"text\" class=\"form-control\" name=\"mx_priority\" id=\"mx_priority\" placeholder=\"10\"> \
+                                <input type=\"text\" class=\"form-control\" name=\"mx_priority\" id=\"mx_priority\" placeholder=\"eg. 10\"> \
                                 <label for=\"mx_server\">MX Server</label> \
-                                <input type=\"text\" class=\"form-control\" name=\"mx_server\" id=\"mx_server\" placeholder=\"postfix.example.com\"> \
+                                <input type=\"text\" class=\"form-control\" name=\"mx_server\" id=\"mx_server\" placeholder=\"eg. postfix.example.com\"> \
                             ";
             } else {
                 var parts = record_data.val().split(" ");
                 var form = "    <label for=\"mx_priority\">MX Priority</label> \
-                                <input type=\"text\" class=\"form-control\" name=\"mx_priority\" id=\"mx_priority\" placeholder=\"10\" value=\"" + parts[0] + "\"> \
+                                <input type=\"text\" class=\"form-control\" name=\"mx_priority\" id=\"mx_priority\" placeholder=\"eg. 10\" value=\"" + parts[0] + "\"> \
                                 <label for=\"mx_server\">MX Server</label> \
-                                <input type=\"text\" class=\"form-control\" name=\"mx_server\" id=\"mx_server\" placeholder=\"postfix.example.com\" value=\"" + parts[1] + "\"> \
+                                <input type=\"text\" class=\"form-control\" name=\"mx_server\" id=\"mx_server\" placeholder=\"eg. postfix.example.com\" value=\"" + parts[1] + "\"> \
                             ";
             }
             modal.find('.modal-body p').html(form);

--- a/app/templates/domain_management.html
+++ b/app/templates/domain_management.html
@@ -59,6 +59,22 @@
         <div class="col-xs-12">
             <div class="box">
                 <div class="box-header">
+                    <h3 class="box-title">Auto PTR creation</h3>
+                </div>
+                <div class="box-body">
+                    <p><input type="checkbox" id="{{ domain.name }}" class="auto_ptr_toggle"
+                         {% for setting in domain.settings %}{% if setting.setting=='auto_ptr' and setting.value=='True' %}checked{% endif %}{% endfor %} {% if auto_ptr_setting %}disabled="True"{% endif %}>
+                         &nbsp;Allow automatic reverse pointer creation on record updates?{% if
+                         auto_ptr_setting %}</br><code>Auto-ptr is enabled globally on the PDA system!</code>{% endif %}</p>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="box">
+                <div class="box-header">
                     <h3 class="box-title">DynDNS 2 Settings</h3>
                 </div>
                 <div class="box-body">
@@ -94,6 +110,10 @@ $('.dyndns_on_demand_toggle').iCheck({
     checkboxClass : 'icheckbox_square-blue',
     increaseArea : '20%' // optional
 });
+$('.auto_ptr_toggle').iCheck({
+    checkboxClass : 'icheckbox_square-blue',
+    increaseArea : '20%' // optional
+});
 
 $("#domain_multi_user").multiSelect();
 
@@ -105,6 +125,18 @@ $('.dyndns_on_demand_toggle').on('ifToggled', function(event) {
         'action' : 'set_setting',
         'data' : {
             'setting' : 'create_via_dyndns',
+            'value' : is_checked
+        }
+    };
+    applyChanges(postdata,  $SCRIPT_ROOT + '/domain/' + domain + '/managesetting', true);
+});
+$('.auto_ptr_toggle').on('ifToggled', function(event) {
+    var is_checked = $(this).prop('checked');
+    var domain = $(this).prop('id');
+    postdata = {
+        'action' : 'set_setting',
+        'data' : {
+            'setting' : 'auto_ptr',
             'value' : is_checked
         }
     };

--- a/app/views.py
+++ b/app/views.py
@@ -58,6 +58,11 @@ def inject_default_domain_table_size_setting():
     default_domain_table_size_setting = Setting.query.filter(Setting.name == 'default_domain_table_size').first()
     return dict(default_domain_table_size_setting=default_domain_table_size_setting.value)
 
+@app.context_processor
+def inject_auto_ptr_setting():
+    auto_ptr_setting = Setting.query.filter(Setting.name == 'auto_ptr').first()
+    return dict(auto_ptr_setting=strtobool(auto_ptr_setting.value))
+
 # START USER AUTHENTICATION HANDLER
 @app.before_request
 def before_request():

--- a/app/views.py
+++ b/app/views.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import traceback
+import re
 from distutils.util import strtobool
 from distutils.version import StrictVersion
 from functools import wraps
@@ -317,8 +318,11 @@ def domain(domain_name):
                 if jr['type'] in app.config['RECORDS_ALLOW_EDIT']:
                     record = Record(name=jr['name'], type=jr['type'], status='Disabled' if jr['disabled'] else 'Active', ttl=jr['ttl'], data=jr['content'])
                     records.append(record)
-                
-        return render_template('domain.html', domain=domain, records=records, editable_records=app.config['RECORDS_ALLOW_EDIT'])
+        if not re.search('ip6\.arpa|in-addr\.arpa$', domain_name):
+            editable_records = app.config['RECORDS_ALLOW_EDIT']
+        else:
+            editable_records = ['PTR']
+        return render_template('domain.html', domain=domain, records=records, editable_records=editable_records)
     else:
         return redirect(url_for('error', code=404))
 

--- a/config_template.py
+++ b/config_template.py
@@ -79,3 +79,7 @@ RECORDS_ALLOW_EDIT = ['A', 'AAAA', 'CNAME', 'SPF', 'PTR', 'MX', 'TXT']
 
 # EXPERIMENTAL FEATURES
 PRETTY_IPV6_PTR = False
+
+# Create reverse lookup domain if not exists and PTR record from
+# A and AAAA records
+AUTOMATIC_REVERSE_PTR = False

--- a/config_template.py
+++ b/config_template.py
@@ -79,7 +79,3 @@ RECORDS_ALLOW_EDIT = ['A', 'AAAA', 'CNAME', 'SPF', 'PTR', 'MX', 'TXT']
 
 # EXPERIMENTAL FEATURES
 PRETTY_IPV6_PTR = False
-
-# Create reverse lookup domain if not exists and PTR record from
-# A and AAAA records
-AUTOMATIC_REVERSE_PTR = False

--- a/create_db.py
+++ b/create_db.py
@@ -77,7 +77,8 @@ def init_records():
         Setting('record_helper', 'True'),
         Setting('login_ldap_first', 'True'),
         Setting('default_record_table_size', '15'),
-        Setting('default_domain_table_size', '10')
+        Setting('default_domain_table_size', '10'),
+        Setting('auto_ptr','False')
     ])
 
     db_commit = db.session.commit()


### PR DESCRIPTION
I've created my own non solution of creating auto PTR records. This way is different from #102 

In my pull request I've solved the automatic reverse domain creation with the user privileges of the original domain. And now I working on the record deleting and updating. In this case it isn't necessary to send set-ptr: auto in PATCH to pdnsd, and it is working on older version <4.0.0 of it. 

I'll create in this pull request the following things:
* [x] safely update, delete the existing ptr records
* [x] ability on gui to choose of creating ptr records from A or AAAA

Please review my solution and discuss.

**UPDATE:**
~~I'll create a NATIVE auto-ptr functionality to my own~~
~~* [ ] Use pdnsd set-ptr record~~

**UPDATE2:**
I see that the native version of auto-ptr functionality isnt working very well in all conditions.