### PR TITLE
Do not update domains from API on every dashboard request

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -124,6 +124,9 @@
           <div class="box">
             <div class="box-header">
               <h3 class="box-title">Hosted Domains</h3>
+              <button type="button" class="btn btn-flat btn-primary update-domains-button pull-right">
+                Refresh Domains&nbsp;<i class="fa fa-refresh"></i>
+              </button>
             </div>
             <!-- /.box-header -->
             <!--
@@ -241,6 +244,13 @@
     $(document.body).on("click", ".button_dnssec", function() {
         var domain = $(this).prop('id');
         getdnssec($SCRIPT_ROOT + '/domain/' + domain + '/dnssec');
+    });
+    $(document.body).on("click", ".update-domains-button", function() {
+        var icon = $(".fa", this).addClass("fa-spin");
+        $.post("/update-domains", {}, function () {
+            icon.removeClass("fa-spin");
+            window.location.reload();
+        });
     });
 </script>
 {% endblock %}

--- a/app/views.py
+++ b/app/views.py
@@ -270,7 +270,6 @@ def logout():
 @app.route('/dashboard', methods=['GET', 'POST'])
 @login_required
 def dashboard():
-    d = Domain().update()
     if current_user.role.name == 'Administrator':
         domains = Domain.query.all()
     else:

--- a/app/views.py
+++ b/app/views.py
@@ -289,6 +289,13 @@ def dashboard():
     return render_template('dashboard.html', domains=domains, domain_count=domain_count, users=users, history_number=history_number, uptime=uptime, histories=history)
 
 
+@app.route('/update-domains', methods=['POST'])
+@login_required
+def update_domains():
+    result = Domain().update()
+    return jsonify(result)
+
+
 @app.route('/domain/<path:domain_name>', methods=['GET', 'POST'])
 @app.route('/domain', methods=['GET', 'POST'])
 @login_required


### PR DESCRIPTION
Currently, viewing the dashboard does a request to the PowerDNS API and updates all domains. With large numbers of domains, this can take a substantial amount of time.

With this change, the domain list is only refreshed when the user clicks the 'refresh' button.