### PR TITLE
Format history date/time before display using browser timezone

### DIFF
--- a/app/templates/admin_history.html
+++ b/app/templates/admin_history.html
@@ -68,7 +68,15 @@
         "searching" : true,
         "ordering" : true,
         "info" : true,
-        "autoWidth" : false
+        "autoWidth" : false,
+        "columnDefs": [
+            {
+                "render": function ( data, type, row ) {
+                    return moment.utc(data).local().format('YYYY-MM-DD HH:mm:ss');
+                },
+                "targets": 2
+            }
+        ]
     });
     $(document.body).on('click', '.history-info-button', function() {
         var modal = $("#modal_history_info");

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -188,6 +188,8 @@
 <script src="{{ url_for('static', filename='adminlte2/plugins/iCheck/icheck.min.js') }}"></script>
 <!-- FastClick -->
 <script src="{{ url_for('static', filename='adminlte2/plugins/fastclick/fastclick.js') }}"></script>
+<!-- Moment.js -->
+<script src="{{ url_for('static', filename='adminlte2/plugins/daterangepicker/moment.min.js') }}"></script>
 <!-- AdminLTE App -->
 <script src="{{ url_for('static', filename='adminlte2/dist/js/app.min.js') }}"></script>
 <!-- Multiselect -->

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -162,7 +162,15 @@
         "searching" : false,
         "ordering" : false,
         "info" : false,
-        "autoWidth" : false
+        "autoWidth" : false,
+        "columnDefs": [
+            {
+                "render": function ( data, type, row ) {
+                    return moment.utc(data).local().format('YYYY-MM-DD HH:mm:ss');
+                },
+                "targets": 2
+            }
+        ]
     });
     // set up domain list
     $("#tbl_domain_list").DataTable({


### PR DESCRIPTION
Fetch UTC date/time directly from DB and display it could be confused user.

It would be better to format it using user's browser timezone before display it to the user.