### PR TITLE
Add ALLOW_HISTORY_CLEAR configuration to control history clearing behavior

### DIFF
--- a/app/templates/admin_history.html
+++ b/app/templates/admin_history.html
@@ -20,11 +20,13 @@
                 <div class="box-header">
                     <h3 class="box-title">History Management</h3>
                 </div>
+                {% if allow_history_clear %}
                 <div class="box-body clearfix">
                     <button type="button" class="btn btn-flat btn-danger pull-right" data-toggle="modal" data-target="#modal_clear_history">
                         Clear History&nbsp;<i class="fa fa-trash"></i>
                     </button>
                 </div>
+                {% endif %}
                 <div class="box-body">
                     <table id="tbl_history" class="table table-bordered table-striped">
                         <thead>

--- a/app/views.py
+++ b/app/views.py
@@ -1140,8 +1140,12 @@ def admin_manageuser():
 @admin_role_required
 def admin_history():
     if request.method == 'POST':
-        h = History()
-        result = h.remove_all()
+        result = None
+        ALLOW_HISTORY_CLEAR = app.config['ALLOW_HISTORY_CLEAR']
+        if ALLOW_HISTORY_CLEAR == True:
+            h = History()
+            result = h.remove_all()
+
         if result:
             history = History(msg='Remove all histories', created_by=current_user.username)
             history.add()
@@ -1152,7 +1156,7 @@ def admin_history():
 
     if request.method == 'GET':
         histories = History.query.all()
-        return render_template('admin_history.html', histories=histories)
+        return render_template('admin_history.html', histories=histories,allow_history_clear=app.config['ALLOW_HISTORY_CLEAR'])
 
 
 @app.route('/admin/settings', methods=['GET'])

--- a/config_template.py
+++ b/config_template.py
@@ -127,3 +127,6 @@ REVERSE_RECORDS_ALLOW_EDIT = ['SOA', 'TXT', 'LOC', 'NS', 'PTR']
 
 # EXPERIMENTAL FEATURES
 PRETTY_IPV6_PTR = False
+
+# Allow history clearing in history management tab
+ALLOW_HISTORY_CLEAR = True

--- a/configs/development.py
+++ b/configs/development.py
@@ -117,3 +117,6 @@ REVERSE_RECORDS_ALLOW_EDIT = ['SOA', 'TXT', 'LOC', 'NS', 'PTR']
 
 # EXPERIMENTAL FEATURES
 PRETTY_IPV6_PTR = False
+
+# Allow history clearing in history management tab
+ALLOW_HISTORY_CLEAR = True


### PR DESCRIPTION
DNS administrator might not like to allow any people who got admin permission to clear the history log in order to keep track who commit the changes to their DNS system.

This new config uses to control history clearing behavior in history management tab
If this key is set to False, clear history log is prohibited and 'Clear History' button in History Management page will be hidden.

I set ALLOW_HISTORY_CLEAR = True in config file to preserve current behavior.