### PR TITLE
Fail when non-numeric otp token was inserted

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -276,7 +276,7 @@ def login():
 
         # check if user enabled OPT authentication
         if user.otp_secret:
-            if otp_token:
+            if otp_token and isinstance(otp_token, int):
                 good_token = user.verify_totp(otp_token)
                 if not good_token:
                     return render_template('login.html', error='Invalid credentials', ldap_enabled=LDAP_ENABLE, login_title=LOGIN_TITLE, basic_enabled=BASIC_ENABLED, signup_enabled=SIGNUP_ENABLED)


### PR DESCRIPTION
Please observe this (very small) change. It is needed to friendly fail with a message when a non-numeric otp was inserted.

Thanks!

Regards René Dekkers