### PR TITLE
Fix SOA-EDIT-API options

### DIFF
--- a/app/templates/domain_add.html
+++ b/app/templates/domain_add.html
@@ -63,27 +63,12 @@
                         <label>SOA-EDIT-API</label>
                         <div class="radio">
                             <label>
-                                <input type="radio" name="radio_type_soa_edit_api" id="radio_off" value="OFF" checked> (OFF)
+                                <input type="radio" name="radio_type_soa_edit_api" id="radio_default" value="DEFAULT" checked> DEFAULT
                             </label>
                         </div>
                         <div class="radio">
                             <label>
-                                <input type="radio" name="radio_type_soa_edit_api" id="radio_inception_increment" value="INCEPTION-INCREMENT"> INCEPTION-INCREMENT
-                            </label>
-                        </div>
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="radio_type_soa_edit_api" id="radio_inception" value="INCEPTION"> INCEPTION
-                            </label>
-                        </div>
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="radio_type_soa_edit_api" id="radio_increment_week" value="INCREMENT-WEEK"> INCREMENT-WEEK
-                            </label>
-                        </div>
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="radio_type_soa_edit_api" id="radio_increment_weeks" value="INCREMENT-WEEKS"> INCREMENT-WEEKS
+                                <input type="radio" name="radio_type_soa_edit_api" id="radio_increase" value="INCREASE"> INCREASE
                             </label>
                         </div>
                         <div class="radio">
@@ -93,7 +78,7 @@
                         </div>
                         <div class="radio">
                             <label>
-                                <input type="radio" name="radio_type_soa_edit_api" id="radio_inception_epoch" value="INCEPTION-EPOCH"> INCEPTION-EPOCH
+                                <input type="radio" name="radio_type_soa_edit_api" id="radio_off" value="OFF"> OFF
                             </label>
                         </div>
                     </div>
@@ -132,28 +117,19 @@
                         </ul>
                     </dd>
                     <dt>SOA-EDIT-API</dt>
-                    <dd>The SOA-EDIT-API setting defines when and how the SOA serial number will be updated after a change is made to the domain.
+                    <dd>The SOA-EDIT-API setting defines how the SOA serial number will be updated after a change is made to the domain.
                         <ul>
-                            <li>
-                                (OFF) - Not set
+	                    <li>
+                                DEFAULT - Generate a soa serial of YYYYMMDD01. If the current serial is lower than the generated serial, use the generated serial. If the current serial is higher or equal to the generated serial, increase the current serial by 1.
                             </li>
                             <li>
-                                INCEPTION-INCREMENT - Uses YYYYMMDDSS format for SOA serial numbers. If the SOA serial from the backend is within two days after inception, it gets incremented by two (the backend should keep SS below 98).
+                                INCREASE - Increase the current serial by 1.
                             </li>
                             <li>
-                                INCEPTION - Sets the SOA serial to the last inception time in YYYYMMDD01 format. Uses localtime to find the day for inception time. <strong>Not recomended.</strong>
+                                EPOCH - Change the serial to the number of seconds since the EPOCH, aka unixtime.
                             </li>
                             <li>
-                                INCREMENT-WEEK - Sets the SOA serial to the number of weeks since the epoch, which is the last inception time in weeks. <strong>Not recomended.</strong>
-                            </li>
-                            <li>
-                                INCREMENT-WEEKS - Increments the serial with the number of weeks since the UNIX epoch. This should work in every setup; but the result won't look like YYYYMMDDSS anymore.
-                            </li>
-                            <li>
-                                EPOCH - Sets the SOA serial to the number of seconds since the epoch.
-                            </li>
-                            <li>
-                                INCEPTION-EPOCH - Sets the new SOA serial number to the maximum of the old SOA serial number, and age in seconds of the last inception. 
+                                OFF - Disable automatic updates of the SOA serial.
                             </li>
                         </ul>
                     </dd>

--- a/app/templates/domain_management.html
+++ b/app/templates/domain_management.html
@@ -109,41 +109,29 @@
                     <h3 class="box-title">Change SOA-EDIT-API</h3>
                 </div>
                 <div class="box-body">
-                    <p>The SOA-EDIT-API setting defines when and how the SOA serial number will be updated after a change is made to the domain.</p>
+                    <p>The SOA-EDIT-API setting defines how the SOA serial number will be updated after a change is made to the domain.</p>
                     <ul>
                             <li>
-                                (OFF) - Not set
+                                DEFAULT - Generate a soa serial of YYYYMMDD01. If the current serial is lower than the generated serial, use the generated serial. If the current serial is higher or equal to the generated serial, increase the current serial by 1.
                             </li>
                             <li>
-                                INCEPTION-INCREMENT - Uses YYYYMMDDSS format for SOA serial numbers. If the SOA serial from the backend is within two days after inception, it gets incremented by two (the backend should keep SS below 98).
+                                INCREASE - Increase the current serial by 1.
                             </li>
                             <li>
-                                INCEPTION - Sets the SOA serial to the last inception time in YYYYMMDD01 format. Uses localtime to find the day for inception time. <strong>Not recomended.</strong>
+                                EPOCH - Change the serial to the number of seconds since the EPOCH, aka unixtime.
                             </li>
                             <li>
-                                INCREMENT-WEEK - Sets the SOA serial to the number of weeks since the epoch, which is the last inception time in weeks. <strong>Not recomended.</strong>
-                            </li>
-                            <li>
-                                INCREMENT-WEEKS - Increments the serial with the number of weeks since the UNIX epoch. This should work in every setup; but the result won't look like YYYYMMDDSS anymore.
-                            </li>
-                            <li>
-                                EPOCH - Sets the SOA serial to the number of seconds since the epoch.
-                            </li>
-                            <li>
-                                INCEPTION-EPOCH - Sets the new SOA serial number to the maximum of the old SOA serial number, and age in seconds of the last inception.
+                                OFF - Disable automatic updates of the SOA serial.
                             </li>
                         </ul>
                     <b>New SOA-EDIT-API Setting:</b>
                     <form method="post" action="{{ url_for('domain_change_soa_edit_api', domain_name=domain.name) }}">
                     <select name="soa_edit_api" class="form-control" style="width:15em;">
                         <option selected value="0">- Unchanged -</option>
-                        <option>OFF</option>
-                        <option>INCEPTION-INCREMENT</option>
-                        <option>INCEPTION</option>
-                        <option>INCREMENT-WEEK</option>
-                        <option>INCREMENT-WEEKS</option>
+                        <option>DEFAULT</option>
+                        <option>INCREASE</option>
                         <option>EPOCH</option>
-                        <option>INCEPTION-EPOCH</option>
+                        <option>OFF</option>
                     </select><br/>
                     <button type="submit" class="btn btn-flat btn-primary" id="change_soa_edit_api">
                         <i class="fa fa-check"></i>&nbsp;Change SOA-EDIT-API setting for {{ domain.name }}


### PR DESCRIPTION
The options used for `SOA-EDIT-API` in PowerDNS-Admin, are wrong and don't work as expected. They are meant for `SOA-EDIT`, which is something else entirely.

This PR replaces the bad option-list with a new good one and takes care to only pass good values for SOA-EDIT-API to the powerdns API.

Solves #262 - Tested on my own setup.