### PR TITLE
Initial support for Accounts

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -486,7 +486,7 @@ class Account(db.Model):
         """
         account = Account.query.filter(Account.name == account_name).first()
         if account is None:
-            return 0
+            return None
 
         return account.id
 
@@ -664,7 +664,7 @@ class Domain(db.Model):
     notified_serial = db.Column(db.Integer)
     last_check = db.Column(db.Integer)
     dnssec = db.Column(db.Integer)
-    account_id = db.Column(db.Integer, db.ForeignKey('account.id'), nullable = False)
+    account_id = db.Column(db.Integer, db.ForeignKey('account.id'))
     account = db.relationship("Account", back_populates="domains")
     settings = db.relationship('DomainSetting', back_populates='domain')
 

--- a/app/templates/admin_editaccount.html
+++ b/app/templates/admin_editaccount.html
@@ -67,6 +67,21 @@
                         <span class="fa fa-envelope form-control-feedback"></span>
                     </div>
                 </div>
+                <div class="box-header with-border">
+                    <h3 class="box-title">Access Control</h3>
+                </div>
+                <div class="box-body">
+                    <p>Users on the right have access to manage records in all domains
+                        associated with the account.</p>
+                    <p>Click on users to move between columns.</p>
+                    <div class="form-group col-xs-2">
+                        <select multiple="multiple" class="form-control" id="account_multi_user" name="account_multi_user">
+                            {% for user in users %}
+                            <option {% if user.id in account_user_ids %}selected{% endif %} value="{{ user.username }}">{{ user.username }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
                 <div class="box-footer">
                     <button type="submit" class="btn btn-flat btn-primary">{% if create %}Create{% else %}Update{% endif %} Account</button>
                 </div>
@@ -95,4 +110,9 @@
     </div>
 </div>
 </section>
+{% endblock %}
+{% block extrascripts %}
+<script>
+        $("#account_multi_user").multiSelect();
+</script>
 {% endblock %}

--- a/app/templates/admin_editaccount.html
+++ b/app/templates/admin_editaccount.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+{% block title %}<title>DNS Control Panel - Edit Account</title>{% endblock %}
+
+{% block dashboard_stat %}
+    <!-- Content Header (Page header) -->
+    <section class="content-header">
+      <h1>
+        Account
+        <small>{% if create %}New account{% else %}{{ account.name }}{% endif %}</small>
+      </h1>
+      <ol class="breadcrumb">
+        <li><a href="{{ url_for('dashboard') }}"><i class="fa fa-dashboard"></i>Home</a></li>
+        <li><a href="{{ url_for('admin_manageaccount') }}">Accounts</a></li>
+        <li class="active">{% if create %}Add{% else %}Edit{% endif %} account</li>
+      </ol>
+    </section>
+{% endblock %}
+
+{% block content %}
+<section class="content">
+<div class="row">
+    <div class="col-md-4">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">{% if create %}Add{% else %}Edit{% endif %} account</h3>
+            </div>
+            <!-- /.box-header -->
+            <!-- form start -->
+            <form role="form" method="post" action="{% if create %}{{ url_for('admin_editaccount') }}{% else %}{{ url_for('admin_editaccount', account_name=account.name) }}{% endif %}">
+                <input type="hidden" name="create" value="{{ create }}">
+                <div class="box-body">
+                    {% if error %}
+                        <div class="alert alert-danger alert-dismissible">
+                            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                            <h4><i class="icon fa fa-ban"></i> Error!</h4>
+                            {{ error }}
+                         </div>
+                        <span class="help-block">{{ error }}</span>
+                    {% endif %}
+                    <div class="form-group has-feedback {% if invalid_accountname or duplicate_accountname %}has-error{% endif %}">
+                        <label class="control-label" for="accountname">Name</label>
+                        <input type="text" class="form-control" placeholder="Account Name (required)"
+                            name="accountname" {% if account %}value="{{ account.name }}"{% endif %} {% if not create %}disabled{% endif %}>
+                        <span class="fa fa-cog form-control-feedback"></span>
+                        {% if invalid_accountname %}
+                            <span class="help-block">Cannot be blank and must only contain alphanumeric characters.</span>
+                        {% elif duplicate_accountname %}
+                            <span class="help-block">Account name already in use.</span>
+                        {% endif %}
+                    </div>
+                    <div class="form-group has-feedback">
+                        <label class="control-label" for="accountdescription">Description</label>
+                        <input type="text" class="form-control" placeholder="Account Description (optional)"
+                            name="accountdescription" {% if account %}value="{{ account.description }}"{% endif %}>
+                        <span class="fa fa-industry form-control-feedback"></span>
+                    </div>
+                    <div class="form-group has-feedback">
+                        <label class="control-label" for="accountcontact">Contact Person</label>
+                        <input type="text" class="form-control" placeholder="Contact Person (optional)"
+                            name="accountcontact" {% if account %}value="{{ account.contact }}"{% endif %}>
+                        <span class="fa fa-user form-control-feedback"></span>
+                    </div>
+                    <div class="form-group has-feedback">
+                        <label class="control-label" for="accountmail">Mail Address</label>
+                        <input type="email" class="form-control" placeholder="Mail Address (optional)"
+                            name="accountmail" {% if account %}value="{{ account.mail }}"{% endif %}>
+                        <span class="fa fa-envelope form-control-feedback"></span>
+                    </div>
+                </div>
+                <div class="box-footer">
+                    <button type="submit" class="btn btn-flat btn-primary">{% if create %}Create{% else %}Update{% endif %} Account</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="col-md-8">
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <h3 class="box-title">Help with creating a new account</h3>
+            </div>
+            <div class="box-body">
+                <p>
+                    An account allows grouping of domains belonging to a particular entity, such as a customer or department.<br/>
+                    A domain can be assigned to an account upon domain creation or through the domain administration page.
+                </p>
+                <p>Fill in all the fields to the in the form to the left.</p>
+                <p>
+                    <strong>Name</strong> is an account identifier. It will be stored as all lowercase letters (no spaces, special characters etc).<br/>
+                    <strong>Description</strong> is a user friendly name for this account.<br/>
+                    <strong>Contact person</strong> is the name of a contact person at the account.<br/>
+                    <strong>Mail Address</strong> is an e-mail address for the contact person.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+</section>
+{% endblock %}

--- a/app/templates/admin_manageaccount.html
+++ b/app/templates/admin_manageaccount.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %} {% block title %}
+<title>DNS Control Panel - Account Management</title>
+{% endblock %} {% block dashboard_stat %}
+<section class="content-header">
+    <h1>
+        Accounts <small>Manage accounts</small>
+    </h1>
+    <ol class="breadcrumb">
+        <li><a href="{{ url_for('dashboard') }}"><i
+                class="fa fa-dashboard"></i> Home</a></li>
+        <li class="active">Accounts</li>
+    </ol>
+</section>
+{% endblock %} {% block content %}
+<section class="content">
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="box">
+                <div class="box-header">
+                    <h3 class="box-title">Account Management</h3>
+                </div>
+                <div class="box-body">
+                    <a href="{{ url_for('admin_editaccount') }}">
+                        <button type="button" class="btn btn-flat btn-primary pull-left button_add_account">
+                            Add Account&nbsp;<i class="fa fa-plus"></i>
+                        </button>
+                    </a>
+                </div>
+                <div class="box-body">
+                    <table id="tbl_accounts" class="table table-bordered table-striped">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Description</th>
+                                <th>Contact</th>
+                                <th>Mail</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for account in accounts %}
+                            <tr class="odd gradeX">
+                                <td>{{ account.name }}</td>
+                                <td>{{ account.description }}</td>
+                                <td>{{ account.contact }}</td>
+                                <td>{{ account.mail }}</td>
+                                <td width="15%">
+                                    <button type="button" class="btn btn-flat btn-success" onclick="window.location.href='{{ url_for('admin_editaccount', account_name=account.name) }}'">
+                                        Edit&nbsp;<i class="fa fa-cog"></i>
+                                    </button>
+                                    <button type="button" class="btn btn-flat btn-danger button_delete" id="{{ account.name }}">
+                                        Delete&nbsp;<i class="fa fa-trash"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                <!-- /.box-body -->
+            </div>
+            <!-- /.box -->
+        </div>
+        <!-- /.col -->
+    </div>
+    <!-- /.row -->
+</section>
+{% endblock %} 
+{% block extrascripts %}
+<script>
+    // set up accounts data table
+    $("#tbl_accounts").DataTable({
+        "paging" : true,
+        "lengthChange" : true,
+        "searching" : true,
+        "ordering" : true,
+        "columnDefs": [
+            { "orderable": false, "targets": [-1] }
+        ],
+        "info" : false,
+        "autoWidth" : false,
+        "lengthMenu": [ [10, 25, 50, 100, -1],
+                      [10, 25, 50, 100, "All"]],
+        "pageLength": 10
+    });
+
+    // handle deletion of account
+    $(document.body).on('click', '.button_delete', function() {
+        var modal = $("#modal_delete");
+        var accountname = $(this).prop('id');
+        var info = "Are you sure you want to delete " + accountname + "?"; 
+        modal.find('.modal-body p').text(info);
+        modal.find('#button_delete_confirm').click(function() {
+            var postdata = {'action': 'delete_account', 'data': accountname}
+            applyChanges(postdata, $SCRIPT_ROOT + '/admin/manageaccount', false, true);
+            modal.modal('hide');
+        })
+        modal.modal('show');
+    });
+    
+</script>
+{% endblock %}
+{% block modals %}
+<div class="modal fade modal-warning" id="modal_delete">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"
+                    aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title">Confirmation</h4>
+            </div>
+            <div class="modal-body">
+                <p></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-flat btn-default pull-left"
+                    data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-flat btn-danger" id="button_delete_confirm">Delete</button>
+            </div>
+        </div>
+        <!-- /.modal-content -->
+    </div>
+    <!-- /.modal-dialog -->
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -129,6 +129,7 @@
         <li><a href="{{ url_for('admin') }}"><i class="fa fa-wrench"></i> <span>Admin Console</span></a></li>
         <li><a href="{{ url_for('templates') }}"><i class="fa fa-clone"></i> <span>Domain Templates</span></a></li>
         <li><a href="{{ url_for('admin_manageuser') }}"><i class="fa fa-users"></i> <span>Users</span></a></li>
+        <li><a href="{{ url_for('admin_manageaccount') }}"><i class="fa fa-industry"></i> <span>Accounts</span></a></li>
         <li><a href="{{ url_for('admin_history') }}"><i class="fa fa-calendar"></i> <span>History</span></a></li>
         <li><a href="{{ url_for('admin_settings') }}"><i class="fa fa-cog"></i> <span>Settings</span></a></li>
         {% endif %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -134,6 +134,7 @@
                   <th>Type</th>
                   <th>Serial</th>
                   <th>Master</th>
+                  <th>Account</th>
                   <th {% if current_user.role.name !='Administrator' %}width="6%"{% else %}width="25%"{% endif %}>Action</th>
                 </tr>
                 </thead>
@@ -178,6 +179,10 @@
         "lengthChange" : true,
         "searching" : true,
         "ordering" : true,
+        "columnDefs": [
+            { "orderable": false, "targets": [-1] }
+            {% if current_user.role.name != 'Administrator' %},{ "visible": false, "targets": [-2] }{% endif %}
+        ],
         "processing" : true,
         "serverSide" : true,
         "ajax" : "{{ url_for('dashboard_domains') }}",

--- a/app/templates/dashboard_domain.html
+++ b/app/templates/dashboard_domain.html
@@ -22,6 +22,12 @@
     {% if domain.master == '[]'%}N/A{% else %}{{ domain.master|display_master_name }}{% endif %}
 {% endmacro %}
 
+{% macro account(domain) %}
+    {% if current_user.role.name =='Administrator' %}
+      {% if domain.account_description != "" %}{{ domain.account.description }} {% endif %}[{{ domain.account.name }}]
+    {% endif %}
+{% endmacro %}
+
 {% macro actions(domain) %}
   {% if current_user.role.name =='Administrator' %}
     <td width="25%">

--- a/app/templates/domain_add.html
+++ b/app/templates/domain_add.html
@@ -31,6 +31,12 @@
                     <div class="form-group">
                         <input type="text" class="form-control" name="domain_name" id="domain_name" placeholder="Enter a valid domain name (required)">
                     </div>
+                    <select name="accountid" class="form-control" style="width:15em;">
+                        <option value="0">- No Account -</option>
+                        {% for account in accounts %}
+                        <option value="{{ account.id }}">{{ account.name }}</option>
+                        {% endfor %}
+                    </select><br/>
                     <div class="form-group">
                         <label>Type</label>
                         <div class="radio">

--- a/app/templates/domain_management.html
+++ b/app/templates/domain_management.html
@@ -75,6 +75,32 @@
         <div class="col-xs-12">
             <div class="box">
                 <div class="box-header">
+                    <h3 class="box-title">Account</h3>
+                </div>
+                <div class="box-body">
+                    <div class="col-xs-12">
+                        <div class="form-group">
+                            <form method="post" action="{{ url_for('domain_change_account', domain_name=domain.name) }}">
+                                <select name="accountid" class="form-control" style="width:15em;">
+                                    <option value="0">- No Account -</option>
+                                    {% for account in accounts %}
+                                    <option value="{{ account.id }}" {% if domain_account.id == account.id %}selected{% endif %}>{{ account.name }}</option>
+                                    {% endfor %}
+                                </select><br/>
+                                <button type="submit" class="btn btn-flat btn-primary" id="change_soa_edit_api">
+                                    <i class="fa fa-check"></i>&nbsp;Change account for {{ domain.name }}
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="box">
+                <div class="box-header">
                     <h3 class="box-title">Auto PTR creation</h3>
                 </div>
                 <div class="box-body">


### PR DESCRIPTION
This adds initial support for accounts a concept meant to signify a customer, a department or any other entity that somehow owns or manages one or more domains.

Meant to solve #267 but using an approach that allows for greater control and easier management.

The purpose is to be able to assign an account to any number of domains, making it easy to track who owns or manages a domain, significantly improving manageability in setups with a large number of domains.

An account consists of a mandatory, unique `name` and optional `description`, `contact` name and `mail` address. The account `name` is stripped of spaces and symbols, and lower cased before getting stored in the database and in PowerDNS, to help ensure some type of predictability and uniqueness in the database.

The term *account* is actually taken from the PowerDNS database, where the `domains.account` column is used to store the account relationship, in in the form of the account `name`.

The link to a domain in PowerDNS-Admin is done through the `domain.account_id` FOREIGN KEY, that is linked to the `account.id` PRIMARY KEY.

**Important notices**
*Database usage*
As we utilize the `domains.account` column of PowerDNS to properly persist the account relationship in a domain, people using this column for other purposes should be careful. PowerDNS-Admin did not previously use this column at all, so the chance of this being an issue is probably relatively small. 

*Account associations*
If an account is deleted, the account association is actively removed from all it's domains, but the domains themselves will not be modified or deleted in any way. Re-adding an account with the same `name` later, *WILL NOT* restore the old associations associations.

However, if the PowerDNS-Admin database gets re-initialized for whatever reason, adding a new account with a `name` previously assigned to a domain *WILL* restore the association. This helps simplify recovery in case of data loss.

**Account access**
In setups where multiple groups of people are managing a lot of domains, managing access to domains through a simple account relationship will save a lot of time and help ensure access rights are correct.

The account concept has grown the possibility of managing domain access permissions through accounts to provide this exact feature. When creating or editing an account, it's possible to add users to the account, through the same familiar multi select control, used on the domains. Users added to an account, automatically gains access to every domain that is tied to that account. Conversely, removing a user from an account, will revoke his access to all domains tied to the account. 
*Note:* This process does not interfere with per-domain access at all, so a user might still have permission to a domain through per-domain permissions after removing him from an account.