### PR TITLE
Fix OTP validation

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -365,7 +365,7 @@ def login():
 
         # check if user enabled OPT authentication
         if user.otp_secret:
-            if otp_token and isinstance(otp_token, int):
+            if otp_token and otp_token.isdigit():
                 good_token = user.verify_totp(otp_token)
                 if not good_token:
                     return render_template('login.html', error='Invalid credentials',


### PR DESCRIPTION
The result from the form is never an int but rather a string of digits, so that's what we should be checking for.

This fixes OTP validation