### PR TITLE
Restrict certain admin changes on the current user

### DIFF
--- a/app/templates/admin_manageuser.html
+++ b/app/templates/admin_manageuser.html
@@ -47,7 +47,7 @@
                                 <td>{{ user.lastname }}</td>
                                 <td>{{ user.email }}</td>
                                 <td>
-                                    <input type="checkbox" id="{{ user.username }}" class="admin_toggle" {% if user.role.name=='Administrator' %}checked{% endif %}>
+                                    <input type="checkbox" id="{{ user.username }}" class="admin_toggle" {% if user.role.name=='Administrator' %}checked{% endif %} {% if user.username==current_user.username %}disabled{% endif %}>
                                 </td>
                                 <td width="6%">
                                     <button type="button" class="btn btn-flat btn-warning button_revoke" id="{{ user.username }}">
@@ -55,7 +55,7 @@
                                     </button>
                                 </td>
                                 <td width="6%">
-                                    <button type="button" class="btn btn-flat btn-danger button_delete" id="{{ user.username }}">
+                                    <button type="button" class="btn btn-flat btn-danger button_delete" id="{{ user.username }}" {% if user.username==current_user.username %}disabled{% endif %}>
                                         Delete&nbsp;<i class="fa fa-trash"></i>
                                     </button>
                                 </td>

--- a/app/views.py
+++ b/app/views.py
@@ -1098,6 +1098,8 @@ def admin_manageuser():
             data = jdata['data']
 
             if jdata['action'] == 'delete_user':
+                if username == current_user.username:
+                    return make_response(jsonify( { 'status': 'error', 'msg': 'You cannot delete yourself.' } ), 400)
                 user = User(username=data)
                 result = user.delete()
                 if result:
@@ -1119,6 +1121,8 @@ def admin_manageuser():
 
             elif jdata['action'] == 'set_admin':
                 username = data['username']
+                if username == current_user.username:
+                    return make_response(jsonify( { 'status': 'error', 'msg': 'You cannot change you own admin rights.' } ), 400)
                 is_admin = data['is_admin']
                 user = User(username=username)
                 result = user.set_admin(is_admin)


### PR DESCRIPTION
Disable the admin toggle and delete operations from the current user, to avoid accidents.
