### PR TITLE
Enable pool_pre_ping in DB connection

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,15 @@
 from werkzeug.contrib.fixers import ProxyFix
 from flask import Flask, request, session, redirect, url_for
 from flask_login import LoginManager
-from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy as SA
+
+
+# subclass SQLAlchemy to enable pool_pre_ping
+class SQLAlchemy(SA):
+    def apply_pool_defaults(self, app, options):
+        SA.apply_pool_defaults(self, app, options)
+        options["pool_pre_ping"] = True
+
 
 app = Flask(__name__)
 app.config.from_object('config')


### PR DESCRIPTION
To avoid problems with inactive DB connections, SQLAlchemy provides a `pool_pre_ping` option, that is described in more detail here:

http://docs.sqlalchemy.org/en/latest/core/pooling.html#disconnect-handling-pessimistic

In Flask environments, it's enabled by subclassing SQLAlchemy, which is what I've done here.

This fixes errors like:
sqlalchemy.exc.OperationalError: (_mysql_exceptions.OperationalError) (2006, 'MySQL server has gone away') which results in an Error 500 in the UI.