### PR TITLE
Add Visual Studio Code settings folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # pycharm
 .idea
 
+# vscode
+.vscode
+
 *.py[cod]
 
 # Installer logs


### PR DESCRIPTION
Just as we ignore special files/folders for the Eclipse and PyCharm IDEs, please ignore .vscode used by Visual Studio Code.