### PR TITLE
Improve setting handling

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1731,7 +1731,7 @@ class Setting(db.Model):
         self.name = name
         self.value = value
 
-    def set_mainteance(self, mode):
+    def set_maintenance(self, mode):
         maintenance = Setting.query.filter(Setting.name=='maintenance').first()
 
         if maintenance is None:

--- a/app/templates/admin_settings.html
+++ b/app/templates/admin_settings.html
@@ -30,21 +30,21 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for setting in settings %}
+                            {% for setting_name, setting_value in settings.items() %}
                             <tr class="odd ">
-                                <td>{{ setting.name }}</td>
-                                {% if setting.value == "True" or setting.value == "False" %}
-                                <td>{{ setting.value }}</td>
+                                <td>{{ setting_name }}</td>
+                                {% if setting_value == "True" or setting_value == "False" %}
+                                <td>{{ setting_value }}</td>
                                 {% else %}
-                                <td><input name="value" id="value" value="{{ setting.value }}"></td>
+                                <td><input name="value" id="value" value="{{ setting_value }}"></td>
                                 {% endif %}
                                 <td width="6%">
-                                    {% if setting.value == "True" or setting.value == "False" %}
-                                    <button type="button" class="btn btn-flat btn-warning setting-toggle-button" id="{{ setting.name }}">
+                                    {% if setting_value == "True" or setting_value == "False" %}
+                                    <button type="button" class="btn btn-flat btn-warning setting-toggle-button" id="{{ setting_name }}">
                                         Toggle&nbsp;<i class="fa fa-info"></i>
                                     </button>
                                     {% else %}
-                                    <button type="button" class="btn btn-flat btn-warning setting-save-button" id="{{ setting.name }}">
+                                    <button type="button" class="btn btn-flat btn-warning setting-save-button" id="{{ setting_name }}">
                                         Save&nbsp;<i class="fa fa-info"></i>
                                     </button>
                                     {% endif %}

--- a/app/views.py
+++ b/app/views.py
@@ -45,49 +45,46 @@ else:
 
 @app.context_processor
 def inject_fullscreen_layout_setting():
-    fullscreen_layout_setting = Setting.query.filter(Setting.name == 'fullscreen_layout').first()
-    return dict(fullscreen_layout_setting=strtobool(fullscreen_layout_setting.value))
+    setting_value = Setting().get('fullscreen_layout')
+    return dict(fullscreen_layout_setting=strtobool(setting_value))
 
 
 @app.context_processor
 def inject_record_helper_setting():
-    record_helper_setting = Setting.query.filter(Setting.name == 'record_helper').first()
-    return dict(record_helper_setting=strtobool(record_helper_setting.value))
+    setting_value = Setting().get('record_helper')
+    return dict(record_helper_setting=strtobool(setting_value))
 
 
 @app.context_processor
 def inject_login_ldap_first_setting():
-    login_ldap_first_setting = Setting.query.filter(Setting.name == 'login_ldap_first').first()
-    return dict(login_ldap_first_setting=strtobool(login_ldap_first_setting.value))
+    setting_value = Setting().get('login_ldap_first')
+    return dict(login_ldap_first_setting=strtobool(setting_value))
 
 
 @app.context_processor
 def inject_default_record_table_size_setting():
-    default_record_table_size_setting = Setting.query.filter(Setting.name == 'default_record_table_size').first()
-    return dict(default_record_table_size_setting=default_record_table_size_setting.value)
+    setting_value = Setting().get('default_record_table_size')
+    return dict(default_record_table_size_setting=setting_value)
 
 
 @app.context_processor
 def inject_default_domain_table_size_setting():
-    default_domain_table_size_setting = Setting.query.filter(Setting.name == 'default_domain_table_size').first()
-    return dict(default_domain_table_size_setting=default_domain_table_size_setting.value)
+    setting_value = Setting().get('default_domain_table_size')
+    return dict(default_domain_table_size_setting=setting_value)
 
 
 @app.context_processor
 def inject_auto_ptr_setting():
-    auto_ptr_setting = Setting.query.filter(Setting.name == 'auto_ptr').first()
-    if auto_ptr_setting is None:
-        return dict(auto_ptr_setting=False)
-    else:
-        return dict(auto_ptr_setting=strtobool(auto_ptr_setting.value))
+    setting_value = Setting().get('auto_ptr')
+    return dict(auto_ptr_setting=strtobool(setting_value))
 
 
 # START USER AUTHENTICATION HANDLER
 @app.before_request
 def before_request():
     # check site maintenance mode first
-    maintenance = Setting.query.filter(Setting.name == 'maintenance').first()
-    if maintenance and maintenance.value == 'True':
+    maintenance = Setting().get('maintenance')
+    if strtobool(maintenance):
         return render_template('maintenance.html')
 
     # check if user is anonymous
@@ -1307,7 +1304,16 @@ def admin_history():
 @admin_role_required
 def admin_settings():
     if request.method == 'GET':
-        settings = Setting.query.filter(Setting.name != 'maintenance')
+        # start with a copy of the setting defaults (ignore maintenance setting)
+        settings = Setting.defaults.copy()
+        settings.pop('maintenance', None)
+
+        # update settings info with any customizations
+        for s in settings:
+            value = Setting().get(s)
+            if value is not None:
+                settings[s] = value
+
         return render_template('admin_settings.html', settings=settings)
 
 

--- a/init_data.py
+++ b/init_data.py
@@ -6,28 +6,12 @@ from app.models import Role, Setting, DomainTemplate
 admin_role = Role(name='Administrator', description='Administrator')
 user_role = Role(name='User', description='User')
 
-setting_1 = Setting(name='maintenance', value='False')
-setting_2 = Setting(name='fullscreen_layout', value='True')
-setting_3 = Setting(name='record_helper', value='True')
-setting_4 = Setting(name='login_ldap_first', value='True')
-setting_5 = Setting(name='default_record_table_size', value='15')
-setting_6 = Setting(name='default_domain_table_size', value='10')
-setting_7 = Setting(name='auto_ptr', value='False')
-
 template_1 = DomainTemplate(name='basic_template_1', description='Basic Template #1')
 template_2 = DomainTemplate(name='basic_template_2', description='Basic Template #2')
 template_3 = DomainTemplate(name='basic_template_3', description='Basic Template #3')
 
 db.session.add(admin_role)
 db.session.add(user_role)
-
-db.session.add(setting_1)
-db.session.add(setting_2)
-db.session.add(setting_3)
-db.session.add(setting_4)
-db.session.add(setting_5)
-db.session.add(setting_6)
-db.session.add(setting_7)
 
 db.session.add(template_1)
 db.session.add(template_2)


### PR DESCRIPTION
Moves setting definitions into code (rather than database).

Aims to fix issues such as #175 and #194 .

For a setting to be useful, the code has to be able to make sense of it anyway. For this reason it makes sense, that the available settings are defined within the code, rather than in the database, where a missing row has previously caused problems. Instead, settings are now written to the database, when they are changed.

So instead of relying on the database initialization process to create all available settings for us in the database, the supported settings and their defaults are now in a `defaults` dict in the Setting class. With this in place, we can stop populating the `setting` table as a part of database initialization and it will be much easier to support new settings in the future (we no longer need to do anything to the database, to achieve that).

Another benefit is that any changes to default values will take effect automatically, unless the admin has already modified that setting to his/her liking.

To make it easier to get the value of a setting, falling back to defaults etc, a new function `get` has been added to the Setting class. Call it as `Setting().get('setting_name'), and it will take care of returning a setting from the database or return the default value for that setting, if nothing was found.

The `get` function returns `None`, if the setting passed to the function, does not exist in the `Setting.defaults` dict - Indicating that we don't know of a setting by that name.

---

I've thrown in a simple typo fix to the `set_maintenance` (`set_mainteance`) function. It's a simple change and it would conflict with the setting handling commit here, if I had PR'ed it on it's own. Hopefully this works for you.