### PR TITLE
Add allow quick edit setting

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1717,7 +1717,8 @@ class Setting(db.Model):
         'login_ldap_first': 'True',
         'default_record_table_size': 15,
         'default_domain_table_size': 10,
-        'auto_ptr': 'False'
+        'auto_ptr': 'False',
+        'allow_quick_edit': 'True'
     }
 
     def __init__(self, id=None, name=None, value=None):

--- a/app/templates/domain.html
+++ b/app/templates/domain.html
@@ -161,8 +161,8 @@
         modal.modal('show');
 
     });
-    // handle edit button
-    $(document.body).on("click", ".button_edit, .row_record", function(e) {
+    // handle edit button and record click
+    $(document.body).on("click", ".button_edit{% if quick_edit %}, .row_record{% endif %}", function(e) {
          e.stopPropagation();
          if ($(this).is('tr')) {
             var nRow = $(this)[0];

--- a/app/views.py
+++ b/app/views.py
@@ -576,6 +576,8 @@ def domain(domain_name):
         # can not get any record, API server might be down
         return redirect(url_for('error', code=500))
 
+    quick_edit = strtobool(Setting().get('allow_quick_edit'))
+
     records = []
     #TODO: This should be done in the "model" instead of "view"
     if NEW_SCHEMA:
@@ -588,7 +590,7 @@ def domain(domain_name):
             editable_records = app.config['RECORDS_ALLOW_EDIT']
         else:
             editable_records = app.config['REVERSE_RECORDS_ALLOW_EDIT']
-        return render_template('domain.html', domain=domain, records=records, editable_records=editable_records)
+        return render_template('domain.html', domain=domain, records=records, editable_records=editable_records, quick_edit=quick_edit)
     else:
         for jr in jrecords:
             if jr['type'] in app.config['RECORDS_ALLOW_EDIT']:
@@ -598,7 +600,7 @@ def domain(domain_name):
         editable_records = app.config['FORWARD_RECORDS_ALLOW_EDIT']
     else:
         editable_records = app.config['REVERSE_RECORDS_ALLOW_EDIT']
-    return render_template('domain.html', domain=domain, records=records, editable_records=editable_records, pdns_version=app.config['PDNS_VERSION'])
+    return render_template('domain.html', domain=domain, records=records, editable_records=editable_records, quick_edit=quick_edit, pdns_version=app.config['PDNS_VERSION'])
 
 
 @app.route('/admin/domain/add', methods=['GET', 'POST'])


### PR DESCRIPTION
Add a setting to allow easily toggle "quick editing" of records on/off through the settings UI.

***Note***: This PR makes use of the improved settings infrastructure proposed in #287, so by necessity includes the changes from that PR here, too. This may require me to do some rework if #287 is merged, which I'm happy to do.

Aims to fix #288 

