### PR TITLE
Wait for MySQL to be ready before initialising/upgrading database when starting container

### DIFF
--- a/docker/PowerDNS-Admin/Dockerfile
+++ b/docker/PowerDNS-Admin/Dockerfile
@@ -22,6 +22,9 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.lis
 RUN apt-get update -y
 RUN apt-get install -y yarn
 
+# Install Netcat for DB healthcheck
+RUN apt-get install -y netcat
+
 # lib for building mysql db driver
 RUN apt-get install -y libmysqlclient-dev
 
@@ -29,7 +32,7 @@ RUN apt-get install -y libmysqlclient-dev
 RUN apt-get install -y libsasl2-dev libldap2-dev libssl-dev
 
 # lib for building python3-saml
-RUN apt-get install -y libxml2-dev libxslt1-dev libxmlsec1-dev libffi-dev pkg-config 
+RUN apt-get install -y libxml2-dev libxslt1-dev libxmlsec1-dev libffi-dev pkg-config
 
 COPY ./requirements.txt /powerdns-admin/requirements.txt
 RUN pip3 install -r requirements.txt

--- a/docker/PowerDNS-Admin/entrypoint.sh
+++ b/docker/PowerDNS-Admin/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# Wait for us to be able to connect to MySQL before proceeding
+until nc -zv \
+  $PDA_DB_HOST \
+  3306;
+do
+  echo "MySQL ($PDA_DB_HOST) is unavailable - sleeping"
+  sleep 1
+done
+
 cd /powerdns-admin
 
 if [ ! -d "/powerdns-admin/migrations" ]; then


### PR DESCRIPTION
Adds a healthcheck on container start to ensure the MySQL DB is ready.
This isn't an issue in the docker-compose because of the way `depends_on` works in v2.1, but when upgrading to newer versions (or orchestrating user a different tool), this becomes an issue when deploying DB and app simultaneously.