### PR TITLE
Fix SQLAlchemy errors when creating LDAP users

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -256,9 +256,9 @@ class User(db.Model):
                 try:
                     # try to get user's firstname & lastname from LDAP
                     # this might be changed in the future
-                    self.firstname = result[0][0][1]['givenName']
-                    self.lastname = result[0][0][1]['sn']
-                    self.email = result[0][0][1]['mail']
+                    self.firstname = result[0][0][1]['givenName'].decode()
+                    self.lastname = result[0][0][1]['sn'].decode()
+                    self.email = result[0][0][1]['mail'].decode()
                 except Exception as e:
                     logging.info("reading ldap data threw an exception {0}".format(e))
 


### PR DESCRIPTION
When creating new users from LDAP, SQLAlchemy will throw a parameter binding exception because the values returned from LDAP lookups are `bytes`, not `str`s like SQLAlchemy expects. This fixes that by `.decode()`ing the values returned from LDAP before trying to do anything with them.

Note that the actual lookup doesn't cause an exception, it's only triggered when actually inserting the user into the database.

This might (probably will) break things when running on Python 2; I'm not sure how much you care about that.