### PR TITLE
Use the dictionary get() method instead of directly accessing a proba…

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -759,7 +759,7 @@ class Domain(db.Model):
 
             # update/add new domain
             for data in jdata:
-                account_id = Account().get_id_by_name(data['account'])
+                account_id = Account().get_id_by_name(data.get('account'))
                 d = dict_db_domain.get(data['name'].rstrip('.'), None)
                 changed = False
                 if d:


### PR DESCRIPTION
…bly not existing key to prevent a KeyError while calling the URL /dashboard-domains-updater - Error message was: Can not update domain table. Error: 'account'