### PR TITLE
Tolerate pdns 3.x API deficiencies

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -486,6 +486,10 @@ class Account(db.Model):
         """
         Convert account_name to account_id
         """
+        # Skip actual database lookup for empty queries
+        if account_name is None or account_name == "":
+            return None
+
         account = Account.query.filter(Account.name == account_name).first()
         if account is None:
             return None
@@ -759,7 +763,11 @@ class Domain(db.Model):
 
             # update/add new domain
             for data in jdata:
-                account_id = Account().get_id_by_name(data['account'])
+                if 'account' in data:
+                    account_id = Account().get_id_by_name(data['account'])
+                else:
+                    logging.debug("No 'account' data found in API result - Unsupported PowerDNS version?")
+                    account_id = None
                 d = dict_db_domain.get(data['name'].rstrip('.'), None)
                 changed = False
                 if d:


### PR DESCRIPTION
PowerDNS 3.x API does not support setting or getting account info.

This patch lets PowerDNS 3.x users use the rest of the interface without problems.
Account stuff still does not work.

A message is logged in debug mode, to help with troubleshooting on newer versions
of PowerDNS.