### PR TITLE
Decode passwords as UTF-8 on profile updates as well

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -339,7 +339,7 @@ class User(db.Model):
         user.firstname = self.firstname if self.firstname else user.firstname
         user.lastname = self.lastname if self.lastname else user.lastname
         user.email = self.email if self.email else user.email
-        user.password = self.get_hashed_password(self.plain_text_password) if self.plain_text_password else user.password
+        user.password = self.get_hashed_password(self.plain_text_password).decode("utf-8") if self.plain_text_password else user.password
         user.avatar = self.avatar if self.avatar else user.avatar
 
         if enable_otp is not None:


### PR DESCRIPTION
Resolves #324 

As mentioned in https://github.com/ngoduykhanh/PowerDNS-Admin/issues/324#issuecomment-411262030, there is an explicit decode to utf-8 on the password [when creating a user](https://github.com/ngoduykhanh/PowerDNS-Admin/blob/c6bb58cfdafb797b015c0de50330467855382cf8/app/models.py#L324), but not on updating a profile. This seems to cause issues with PostgreSQL, as the string it is trying to insert into the `password` column is suddenly twice the length. This PR fixes the issue for Postgres.

Note that I am currently unable to test this in MySQL, so someone else has to do that. :)