### PR TITLE
Allow specifying SAML2 SSO binding format.

### DIFF
--- a/app/lib/utils.py
+++ b/app/lib/utils.py
@@ -19,7 +19,10 @@ if app.config['SAML_ENABLED']:
     from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
     idp_timestamp = datetime(1970, 1, 1)
     idp_data = None
-    idp_data = OneLogin_Saml2_IdPMetadataParser.parse_remote(app.config['SAML_METADATA_URL'], entity_id=app.config.get('SAML_IDP_ENTITY_ID', None))
+    if 'SAML_IDP_ENTITY_ID' in app.config:
+        idp_data = OneLogin_Saml2_IdPMetadataParser.parse_remote(app.config['SAML_METADATA_URL'], entity_id=app.config.get('SAML_IDP_ENTITY_ID', None), required_sso_binding=app.config['SAML_IDP_SSO_BINDING'])
+    else:
+        idp_data = OneLogin_Saml2_IdPMetadataParser.parse_remote(app.config['SAML_METADATA_URL'], entity_id=app.config.get('SAML_IDP_ENTITY_ID', None))
     if idp_data is None:
         print('SAML: IDP Metadata initial load failed')
         exit(-1)
@@ -37,7 +40,10 @@ def get_idp_data():
 
 def retreive_idp_data():
     global idp_data, idp_timestamp
-    new_idp_data = OneLogin_Saml2_IdPMetadataParser.parse_remote(app.config['SAML_METADATA_URL'], entity_id=app.config.get('SAML_IDP_ENTITY_ID', None))
+    if 'SAML_IDP_SSO_BINDING' in app.config:
+        new_idp_data = OneLogin_Saml2_IdPMetadataParser.parse_remote(app.config['SAML_METADATA_URL'], entity_id=app.config.get('SAML_IDP_ENTITY_ID', None), required_sso_binding=app.config['SAML_IDP_SSO_BINDING'])
+    else:
+        new_idp_data = OneLogin_Saml2_IdPMetadataParser.parse_remote(app.config['SAML_METADATA_URL'], entity_id=app.config.get('SAML_IDP_ENTITY_ID', None))
     if new_idp_data is not None:
         idp_data = new_idp_data
         idp_timestamp = datetime.now()

--- a/config_template.py
+++ b/config_template.py
@@ -98,6 +98,10 @@ SAML_METADATA_URL = 'https://<hostname>/FederationMetadata/2007-06/FederationMet
 #Cache Lifetime in Seconds
 SAML_METADATA_CACHE_LIFETIME = 1
 
+# SAML SSO binding format to use
+## Default: library default (urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect)
+#SAML_IDP_SSO_BINDING = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
+
 ## EntityID of the IdP to use. Only needed if more than one IdP is
 ##   in the SAML_METADATA_URL
 ### Default: First (only) IdP in the SAML_METADATA_URL


### PR DESCRIPTION
Fixes ngoduykhanh/PowerDNS-Admin#322

Adds new optional config setting `SAML_IDP_SSO_BINDING` for which [SAML binding format](https://en.wikipedia.org/wiki/SAML_2.0#SAML_2.0_Bindings) to use. If not specified, use library default.