### PR TITLE
Fix double refresh when activating 2FA

### DIFF
--- a/app/templates/user_profile.html
+++ b/app/templates/user_profile.html
@@ -167,7 +167,6 @@
             }
         };
         applyChanges(postdata, $SCRIPT_ROOT + '/user/profile', false, true);
-        location.reload();
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
When toggling Two Factor Authentication, it often takes a few tries to get it to work.
The toggle function ends up reloading the page in two different places, effectively creating a race condition.

This fixes that problem