### PR TITLE
Allow CNAMEs to point to '@'

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1346,10 +1346,12 @@ class Record(object):
                         if ':' in r['record_name']: # dirty ipv6 check
                             r_name = r['record_name']
 
+            r_data = domain if r_type == 'CNAME' and r['record_data'] in ['@', ''] else r['record_data']
+            
             record = {
                         "name": r_name,
                         "type": r_type,
-                        "content": r['record_data'],
+                        "content": r_data,
                         "disabled": True if r['record_status'] == 'Disabled' else False,
                         "ttl": int(r['record_ttl']) if r['record_ttl'] else 3600,
                     }


### PR DESCRIPTION
Often, you need a CNAME to point to the base domain name, but with a lot of domains and a lot of records, it can become tedious and even error prone to have to type out the domain name in full.

This PR enables the use of the shorthand `@` (or blank) for `CNAME` records, so that if a CNAME record is specified to point to '@' or '', it's replaced with the base domain name.