### PR TITLE
Setting a session lifetime

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1808,6 +1808,7 @@ class Setting(db.Model):
         'allow_user_create_domain': False,
         'bg_domain_updates': False,
         'site_name': 'PowerDNS-Admin',
+        'session_timeout': 10,
         'pdns_api_url': '',
         'pdns_api_key': '',
         'pdns_version': '4.1.1',

--- a/app/views.py
+++ b/app/views.py
@@ -3,6 +3,7 @@ import logging as logger
 import os
 import traceback
 import re
+import datetime
 from distutils.util import strtobool
 from distutils.version import StrictVersion
 from functools import wraps
@@ -68,6 +69,11 @@ def before_request():
     if maintenance and current_user.is_authenticated and current_user.role.name not in ['Administrator', 'Operator']:
         return render_template('maintenance.html')
 
+    # Manage session timeout
+    session.permanent = True
+    app.permanent_session_lifetime = datetime.timedelta(minutes=int(Setting().get('session_timeout')))
+    session.modified = True
+    g.user = current_user
 
 @login_manager.user_loader
 def load_user(id):

--- a/app/views.py
+++ b/app/views.py
@@ -1375,7 +1375,8 @@ def admin_setting_basic():
                     'dnssec_admins_only',
                     'allow_user_create_domain',
                     'bg_domain_updates',
-                    'site_name'] 
+                    'site_name',
+                    'session_timeout' ] 
 
         return render_template('admin_setting_basic.html', settings=settings)
 


### PR DESCRIPTION
This patch is meant to have a session timeout shorter than the default flask_login one.
I manually added a new setting called session_timeout in the setting table, with a default value of 10 minutes:
insert into setting(name,value, view) values('session_timeout', 10, 'basic');

I didn't quite understand the way new settings were added in the database depending on the version of alembic (files in migrations/versions), It may be necessary to complement this patch with the proper migration file. 