### PR TITLE
Fix typo Use -> User

### DIFF
--- a/app/templates/admin_edituser.html
+++ b/app/templates/admin_edituser.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% set active_page = "admin_users" %}
-{% block title %}<title>Edit Use - {{ SITE_NAME }}</title>{% endblock %}
+{% block title %}<title>Edit User - {{ SITE_NAME }}</title>{% endblock %}
 
 {% block dashboard_stat %}
     <!-- Content Header (Page header) -->


### PR DESCRIPTION
Just a small typo in the title of the Edit User page