### PR TITLE
Fix for when TOTP starts with 0

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -90,7 +90,7 @@ class User(db.Model):
 
     def verify_totp(self, token):
         totp = pyotp.TOTP(self.otp_secret)
-        return totp.verify(int(token))
+        return totp.verify(token)
 
     def get_hashed_password(self, plain_text_password=None):
         # Hash a password for the first time


### PR DESCRIPTION
PyOTP wants the token as a string, by passing it as an int leading 0s get stripped and verification fails if the token starts with 0.