### PR TITLE
Add ttl_options setting

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,7 @@ import dns.reversename
 import dns.inet
 import dns.name
 import logging as logger
+import pytimeparse
 
 from ast import literal_eval
 from datetime import datetime
@@ -165,7 +166,7 @@ class User(db.Model):
 
     def ad_recursive_groups(self, groupDN):
         """
-        Recursively list groups belonging to a group. It will allow checking deep in the Active Directory 
+        Recursively list groups belonging to a group. It will allow checking deep in the Active Directory
         whether a user is allowed to enter or not
         """
         LDAP_BASE_DN = Setting().get('ldap_base_dn')
@@ -1424,7 +1425,7 @@ class Record(object):
                             r_name = r['record_name']
 
             r_data = domain if r_type == 'CNAME' and r['record_data'] in ['@', ''] else r['record_data']
-            
+
             record = {
                         "name": r_name,
                         "type": r_type,
@@ -1889,6 +1890,7 @@ class Setting(db.Model):
         'oidc_oauth_authorize_url': '',
         'forward_records_allow_edit': {'A': True, 'AAAA': True, 'AFSDB': False, 'ALIAS': False, 'CAA': True, 'CERT': False, 'CDNSKEY': False, 'CDS': False, 'CNAME': True, 'DNSKEY': False, 'DNAME': False, 'DS': False, 'HINFO': False, 'KEY': False, 'LOC': True, 'MX': True, 'NAPTR': False, 'NS': True, 'NSEC': False, 'NSEC3': False, 'NSEC3PARAM': False, 'OPENPGPKEY': False, 'PTR': True, 'RP': False, 'RRSIG': False, 'SOA': False, 'SPF': True, 'SSHFP': False, 'SRV': True, 'TKEY': False, 'TSIG': False, 'TLSA': False, 'SMIMEA': False, 'TXT': True, 'URI': False},
         'reverse_records_allow_edit': {'A': False, 'AAAA': False, 'AFSDB': False, 'ALIAS': False, 'CAA': False, 'CERT': False, 'CDNSKEY': False, 'CDS': False, 'CNAME': False, 'DNSKEY': False, 'DNAME': False, 'DS': False, 'HINFO': False, 'KEY': False, 'LOC': True, 'MX': False, 'NAPTR': False, 'NS': True, 'NSEC': False, 'NSEC3': False, 'NSEC3PARAM': False, 'OPENPGPKEY': False, 'PTR': True, 'RP': False, 'RRSIG': False, 'SOA': False, 'SPF': False, 'SSHFP': False, 'SRV': False, 'TKEY': False, 'TSIG': False, 'TLSA': False, 'SMIMEA': False, 'TXT': True, 'URI': False},
+        'ttl_options': '1 minute,5 minutes,30 minutes,60 minutes,24 hours',
     }
 
     def __init__(self, id=None, name=None, value=None):
@@ -1993,6 +1995,9 @@ class Setting(db.Model):
         if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 6):
             r_name.sort()
         return r_name
+
+    def get_ttl_options(self):
+        return [ (pytimeparse.parse(ttl),ttl) for ttl in self.get('ttl_options').split(',') ]
 
 
 class DomainTemplate(db.Model):

--- a/app/static/custom/js/custom.js
+++ b/app/static/custom/js/custom.js
@@ -112,18 +112,33 @@ function restoreRow(oTable, nRow) {
     oTable.draw();
 }
 
+function sec2str(t){
+    var d = Math.floor(t/86400),
+        h = Math.floor(t/3600) % 24,
+        m = Math.floor(t/60) % 60,
+        s = t % 60;
+    return (d>0?d+' days ':'')+(h>0?h+' hours ':'')+(m>0?m+' minutes ':'')+(s>0?s+' seconds':'');
+}
+
 function editRow(oTable, nRow) {
     var isDisabled = 'true';
     var aData = oTable.row(nRow).data();
     var jqTds = oTable.cells(nRow,'').nodes();
     var record_types = "";
     var ttl_opts = "";
+    var ttl_not_found = true;
     for(var i = 0; i < records_allow_edit.length; i++) {
         var record_type = records_allow_edit[i];
         record_types += "<option value=\"" + record_type + "\">" + record_type + "</option>";
     }
     for(var i = 0; i < ttl_options.length; i++) {
         ttl_opts += "<option value=\"" + ttl_options[i][0] + "\">" + ttl_options[i][1] + "</option>";
+        if (ttl_options[i][0] == aData[3]) {
+          ttl_not_found = false;
+        }
+    }
+    if (ttl_not_found) {
+      ttl_opts += "<option value=\"" + aData[3] + "\">" + sec2str(aData[3]) + "</option>";
     }
     jqTds[0].innerHTML = '<input type="text" id="edit-row-focus" class="form-control input-small" value="' + aData[0] + '">';
     jqTds[1].innerHTML = '<select class="form-control" id="record_type" name="record_type" value="' + aData[1]  + '">' + record_types + '</select>';

--- a/app/static/custom/js/custom.js
+++ b/app/static/custom/js/custom.js
@@ -117,14 +117,18 @@ function editRow(oTable, nRow) {
     var aData = oTable.row(nRow).data();
     var jqTds = oTable.cells(nRow,'').nodes();
     var record_types = "";
+    var ttl_opts = "";
     for(var i = 0; i < records_allow_edit.length; i++) {
         var record_type = records_allow_edit[i];
         record_types += "<option value=\"" + record_type + "\">" + record_type + "</option>";
     }
+    for(var i = 0; i < ttl_options.length; i++) {
+        ttl_opts += "<option value=\"" + ttl_options[i][0] + "\">" + ttl_options[i][1] + "</option>";
+    }
     jqTds[0].innerHTML = '<input type="text" id="edit-row-focus" class="form-control input-small" value="' + aData[0] + '">';
-    jqTds[1].innerHTML = '<select class="form-control" id="record_type" name="record_type" value="' + aData[1]  + '"' + '>' + record_types + '</select>';
-    jqTds[2].innerHTML = '<select class="form-control" id="record_status" name="record_status" value="' + aData[2]  + '"' + '><option value="false">Active</option><option value="true">Disabled</option></select>';
-    jqTds[3].innerHTML = '<select class="form-control" id="record_ttl" name="record_ttl" value="' + aData[3]  + '"' + '><option value="60">1 minute</option><option value="300">5 minutes</option><option value="1800">30 minutes</option><option value="3600">60 minutes</option><option value="86400">24 hours</option></select>';
+    jqTds[1].innerHTML = '<select class="form-control" id="record_type" name="record_type" value="' + aData[1]  + '">' + record_types + '</select>';
+    jqTds[2].innerHTML = '<select class="form-control" id="record_status" name="record_status" value="' + aData[2]  + '"><option value="false">Active</option><option value="true">Disabled</option></select>';
+    jqTds[3].innerHTML = '<select class="form-control" id="record_ttl" name="record_ttl" value="' + aData[3]  + '">' + ttl_opts + '</select>';
     jqTds[4].innerHTML = '<input type="text" style="display:table-cell; width:100% !important" id="current_edit_record_data" name="current_edit_record_data" class="form-control input-small advance-data" value="' + aData[4].replace(/\"/g,"&quot;") + '">';
     jqTds[5].innerHTML = '<button type="button" class="btn btn-flat btn-primary button_save">Save</button>';
     jqTds[6].innerHTML = '<button type="button" class="btn btn-flat btn-primary button_cancel">Cancel</button>';

--- a/app/templates/domain.html
+++ b/app/templates/domain.html
@@ -106,6 +106,7 @@
 <script>
     // superglobals
     window.records_allow_edit = {{ editable_records|tojson }};
+    window.ttl_options = {{ ttl_options|tojson }};
     window.nEditing = null;
     window.nNew = false;
 

--- a/app/templates/template_edit.html
+++ b/app/templates/template_edit.html
@@ -92,6 +92,7 @@
 <script>
     // superglobals
     window.records_allow_edit = {{ editable_records|tojson }};
+    window.ttl_options = {{ ttl_options|tojson }};
     window.nEditing = null;
     window.nNew = false;
 

--- a/app/views.py
+++ b/app/views.py
@@ -1060,6 +1060,7 @@ def edit_template(template):
         t = DomainTemplate.query.filter(DomainTemplate.name == template).first()
         records_allow_to_edit = Setting().get_records_allow_to_edit()
         quick_edit = Setting().get('record_quick_edit')
+        ttl_options = Setting().get_ttl_options()
         if t is not None:
             records = []
             for jr in t.records:
@@ -1067,7 +1068,7 @@ def edit_template(template):
                     record = DomainTemplateRecord(name=jr.name, type=jr.type, status='Disabled' if jr.status else 'Active', ttl=jr.ttl, data=jr.data)
                     records.append(record)
 
-            return render_template('template_edit.html', template=t.name, records=records, editable_records=records_allow_to_edit, quick_edit=quick_edit)
+            return render_template('template_edit.html', template=t.name, records=records, editable_records=records_allow_to_edit, quick_edit=quick_edit, ttl_options=ttl_options)
     except Exception as e:
         logging.error('Cannot open domain template page. DETAIL: {0}'.format(e))
         logging.debug(traceback.format_exc())

--- a/app/views.py
+++ b/app/views.py
@@ -621,6 +621,7 @@ def domain(domain_name):
     records_allow_to_edit = Setting().get_records_allow_to_edit()
     forward_records_allow_to_edit = Setting().get_forward_records_allow_to_edit()
     reverse_records_allow_to_edit = Setting().get_reverse_records_allow_to_edit()
+    ttl_options = Setting().get_ttl_options()
     records = []
 
     if StrictVersion(Setting().get('pdns_version')) >= StrictVersion('4.0.0'):
@@ -633,7 +634,7 @@ def domain(domain_name):
             editable_records = forward_records_allow_to_edit
         else:
             editable_records = reverse_records_allow_to_edit
-        return render_template('domain.html', domain=domain, records=records, editable_records=editable_records, quick_edit=quick_edit)
+        return render_template('domain.html', domain=domain, records=records, editable_records=editable_records, quick_edit=quick_edit, ttl_options=ttl_options)
     else:
         for jr in jrecords:
             if jr['type'] in records_allow_to_edit:
@@ -643,7 +644,7 @@ def domain(domain_name):
         editable_records = forward_records_allow_to_edit
     else:
         editable_records = reverse_records_allow_to_edit
-    return render_template('domain.html', domain=domain, records=records, editable_records=editable_records, quick_edit=quick_edit)
+    return render_template('domain.html', domain=domain, records=records, editable_records=editable_records, quick_edit=quick_edit, ttl_options=ttl_options)
 
 
 @app.route('/admin/domain/add', methods=['GET', 'POST'])
@@ -1402,7 +1403,8 @@ def admin_setting_basic():
                     'allow_user_create_domain',
                     'bg_domain_updates',
                     'site_name',
-                    'session_timeout' ]
+                    'session_timeout',
+                    'ttl_options' ]
 
         return render_template('admin_setting_basic.html', settings=settings)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ cssmin==0.2.0
 jsmin==2.2.2
 Authlib==0.10
 Flask-Seasurf
+pytimeparse


### PR DESCRIPTION
Adds a new setting to define the options in the TTL dropdown when
editing a record. The setting is a comma separated string with the
valid options.

Fixes #362 
