### PR TITLE
Better LDAP authentication settings help text

### DIFF
--- a/app/templates/admin_setting_authentication.html
+++ b/app/templates/admin_setting_authentication.html
@@ -216,7 +216,7 @@
                                             <dd>Define how you want to filter your user in LDAP query.
                                                 <ul>
                                                     <li>
-                                                        Basic filter - The filter that will be applied to all LDAP query by PDA. (e.g. <i>(objectClass=inetorgperson)</i> for OpenLDAP and <i>(objectClass=organizationalPerson)</i> for Active Directory)
+                                                        Basic filter - The filter that will be applied to all LDAP query by PDA. (e.g. <i>"(objectClass=inetorgperson)"</i> for OpenLDAP and <i>"(objectClass=organizationalPerson)"</i> for Active Directory). Please include parentheses.
                                                     </li>
                                                     <li>
                                                         Username field - The field PDA will look for user's username. (e.g. <i>uid</i> for OpenLDAP and <i>sAMAccountName</i> for Active Directory)


### PR DESCRIPTION
In the current help text for configuring LDAP authentication, it isn't really clear that one should include the parentheses. This should help prevent this simple error, helping people save time in the future.