### PR TITLE
dyndns: accept and validate both A and AAAA records; default to client address

### DIFF
--- a/app/lib/utils.py
+++ b/app/lib/utils.py
@@ -2,6 +2,7 @@ import re
 import json
 import requests
 import hashlib
+import ipaddress
 
 from app import app
 from distutils.version import StrictVersion
@@ -291,3 +292,14 @@ def display_setting_state(value):
         return "OFF"
     else:
         return "UNKNOWN"
+
+
+def validate_ipaddress(address):
+        try:
+            ip = ipaddress.ip_address(address)
+        except ValueError:
+            pass
+        else:
+            if isinstance(ip, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+                return [ip]
+        return []

--- a/app/models.py
+++ b/app/models.py
@@ -1666,7 +1666,7 @@ class Record(object):
         jrecords = jdata['records']
 
         for jr in jrecords:
-            if jr['name'] == self.name:
+            if jr['name'] == self.name and jr['type'] == self.type:
                 self.name = jr['name']
                 self.type = jr['type']
                 self.status = jr['disabled']


### PR DESCRIPTION
Besides accepting IPv6 addresses in general, this implements two items from https://help.dyn.com/remote-access-api/perform-update/ regarding the **myip** parameter:

1. Use commas to separate multiple IP addresses in the myip field.

2. If this parameter is not specified, the best IP address the server can determine will be used (some proxy configurations pass the IP in a header, and that is detected by the server). If the IP address passed to the system is not properly formed, it will be ignored and the system’s best guess will be used.