### PR TITLE
fix equality check for DomainSetting when "other" is None

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -731,7 +731,7 @@ class DomainSetting(db.Model):
         return '<DomainSetting {0} for {1}>'.format(setting, self.domain.name)
 
     def __eq__(self, other):
-        return self.setting == other.setting
+        return type(self) == type(other) and self.setting == other.setting
 
     def set(self, value):
         try:


### PR DESCRIPTION
When checking a DomainSetting against None with "==", an exception is thrown. See [here](https://github.com/ngoduykhanh/PowerDNS-Admin/pull/455/files#r255691535) for the explanation.