### PR TITLE
Improve SAML support

### DIFF
--- a/app/lib/utils.py
+++ b/app/lib/utils.py
@@ -3,6 +3,7 @@ import json
 import requests
 import hashlib
 import ipaddress
+import os
 
 from app import app
 from distutils.version import StrictVersion
@@ -244,10 +245,12 @@ def init_saml_auth(req):
     else:
         settings['sp']['NameIDFormat'] = idp_data.get('sp', {}).get('NameIDFormat', 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified')
     settings['sp']['entityId'] = app.config['SAML_SP_ENTITY_ID']
-    cert = open(CERT_FILE, "r").readlines()
-    key = open(KEY_FILE, "r").readlines()
-    settings['sp']['privateKey'] = "".join(key)
-    settings['sp']['x509cert'] = "".join(cert)
+    if os.path.isfile(CERT_FILE):
+      cert = open(CERT_FILE, "r").readlines()
+      settings['sp']['x509cert'] = "".join(cert)
+    if os.path.isfile(KEY_FILE):
+      key = open(KEY_FILE, "r").readlines()
+      settings['sp']['privateKey'] = "".join(key)
     settings['sp']['assertionConsumerService'] = {}
     settings['sp']['assertionConsumerService']['binding'] = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
     settings['sp']['assertionConsumerService']['url'] = own_url+'/saml/authorized'
@@ -273,7 +276,7 @@ def init_saml_auth(req):
     settings['security']['nameIdEncrypted'] = False
     settings['security']['signMetadata'] = True
     settings['security']['wantAssertionsSigned'] = True
-    settings['security']['wantMessagesSigned'] = True
+    settings['security']['wantMessagesSigned'] = app.config.get('SAML_WANT_MESSAGE_SIGNED', True)
     settings['security']['wantNameIdEncrypted'] = False
     settings['contactPerson'] = {}
     settings['contactPerson']['support'] = {}

--- a/app/views.py
+++ b/app/views.py
@@ -344,9 +344,8 @@ def saml_authorized():
         elif admin_group_name in user_groups:
             uplift_to_admin(user)
         elif admin_attribute_name or group_attribute_name:
-            user_role = Role.query.filter_by(name='User').first().id
-            if user.role_id != user_role:
-                user.role_id = user_role
+            if user.role.name != 'User':
+                user.role_id = Role.query.filter_by(name='User').first().id
                 history = History(msg='Demoting {0} to user'.format(user.username), created_by='SAML Assertion')
                 history.add()
         user.plain_text_password = None
@@ -381,9 +380,8 @@ def handle_account(account_name):
 
 
 def uplift_to_admin(user):
-    admin_role = Role.query.filter_by(name='Administrator').first().id
-    if user.role_id != admin_role:
-        user.role_id = admin_role
+    if user.role.name != 'Administrator':
+        user.role_id = Role.query.filter_by(name='Administrator').first().id
         history = History(msg='Promoting {0} to administrator'.format(user.username), created_by='SAML Assertion')
         history.add()
 

--- a/config_template.py
+++ b/config_template.py
@@ -71,6 +71,12 @@ SAML_METADATA_CACHE_LIFETIME = 1
 ### Example: urn:oid:2.5.4.4
 #SAML_ATTRIBUTE_SURNAME = 'urn:oid:2.5.4.4'
 
+## Split into Given name and Surname
+## Useful if your IDP only gives a display name
+### Default: none
+### Example: http://schemas.microsoft.com/identity/claims/displayname
+#SAML_ATTRIBUTE_NAME = 'http://schemas.microsoft.com/identity/claims/displayname'
+
 ## Attribute to use for username
 ### Default: Use NameID instead
 ### Example: urn:oid:0.9.2342.19200300.100.1.1
@@ -83,6 +89,22 @@ SAML_METADATA_CACHE_LIFETIME = 1
 ### If not included in assertion, or set to something other than 'true',
 ###  the user is set as a non-administrator user.
 #SAML_ATTRIBUTE_ADMIN = 'https://example.edu/pdns-admin'
+
+## Attribute to get group from
+### Default: Don't use groups from SAML attribute
+### Example: https://example.edu/pdns-admin-group
+#SAML_ATTRIBUTE_GROUP = 'https://example.edu/pdns-admin'
+
+## Group namem to get admin status from
+### Default: Don't control admin with SAML group
+### Example: https://example.edu/pdns-admin
+#SAML_GROUP_ADMIN_NAME = 'powerdns-admin'
+
+## Attribute to get group to account mappings from
+### Default: None
+### If set, the user will be added and removed from accounts to match
+###  what's in the login assertion if they are in the required group
+#SAML_GROUP_TO_ACCOUNT_MAPPING = 'dev-admins=dev,prod-admins=prod'
 
 ## Attribute to get account names from
 ### Default: Don't control accounts with SAML attribute
@@ -97,6 +119,11 @@ SAML_SP_CONTACT_MAIL = '<contact mail>'
 #Configures if SAML tokens should be encrypted.
 #If enabled a new app certificate will be generated on restart
 SAML_SIGN_REQUEST = False
+
+# Configures if you want to request the IDP to sign the message
+# Default is True
+#SAML_WANT_MESSAGE_SIGNED = True
+
 #Use SAML standard logout mechanism retrieved from idp metadata
 #If configured false don't care about SAML session on logout.
 #Logout from PowerDNS-Admin only and keep SAML session authenticated.

--- a/configs/development.py
+++ b/configs/development.py
@@ -62,6 +62,12 @@ SAML_METADATA_CACHE_LIFETIME = 1
 ### Example: urn:oid:2.5.4.4
 #SAML_ATTRIBUTE_SURNAME = 'urn:oid:2.5.4.4'
 
+## Split into Given name and Surname
+## Useful if your IDP only gives a display name
+### Default: none
+### Example: http://schemas.microsoft.com/identity/claims/displayname
+#SAML_ATTRIBUTE_NAME = 'http://schemas.microsoft.com/identity/claims/displayname'
+
 ## Attribute to use for username
 ### Default: Use NameID instead
 ### Example: urn:oid:0.9.2342.19200300.100.1.1
@@ -74,6 +80,22 @@ SAML_METADATA_CACHE_LIFETIME = 1
 ### If not included in assertion, or set to something other than 'true',
 ###  the user is set as a non-administrator user.
 #SAML_ATTRIBUTE_ADMIN = 'https://example.edu/pdns-admin'
+
+## Attribute to get group from
+### Default: Don't use groups from SAML attribute
+### Example: https://example.edu/pdns-admin-group
+#SAML_ATTRIBUTE_GROUP = 'https://example.edu/pdns-admin'
+
+## Group namem to get admin status from
+### Default: Don't control admin with SAML group
+### Example: https://example.edu/pdns-admin
+#SAML_GROUP_ADMIN_NAME = 'powerdns-admin'
+
+## Attribute to get group to account mappings from
+### Default: None
+### If set, the user will be added and removed from accounts to match
+###  what's in the login assertion if they are in the required group
+#SAML_GROUP_TO_ACCOUNT_MAPPING = 'dev-admins=dev,prod-admins=prod'
 
 ## Attribute to get account names from
 ### Default: Don't control accounts with SAML attribute
@@ -88,6 +110,11 @@ SAML_SP_CONTACT_MAIL = '<contact mail>'
 #Configures if SAML tokens should be encrypted.
 #If enabled a new app certificate will be generated on restart
 SAML_SIGN_REQUEST = False
+
+# Configures if you want to request the IDP to sign the message
+# Default is True
+#SAML_WANT_MESSAGE_SIGNED = True
+
 #Use SAML standard logout mechanism retrieved from idp metadata
 #If configured false don't care about SAML session on logout.
 #Logout from PowerDNS-Admin only and keep SAML session authenticated.

--- a/configs/test.py
+++ b/configs/test.py
@@ -69,6 +69,12 @@ SAML_METADATA_CACHE_LIFETIME = 1
 ### Example: urn:oid:2.5.4.4
 #SAML_ATTRIBUTE_SURNAME = 'urn:oid:2.5.4.4'
 
+## Split into Given name and Surname
+## Useful if your IDP only gives a display name
+### Default: none
+### Example: http://schemas.microsoft.com/identity/claims/displayname
+#SAML_ATTRIBUTE_NAME = 'http://schemas.microsoft.com/identity/claims/displayname'
+
 ## Attribute to use for username
 ### Default: Use NameID instead
 ### Example: urn:oid:0.9.2342.19200300.100.1.1
@@ -81,6 +87,22 @@ SAML_METADATA_CACHE_LIFETIME = 1
 ### If not included in assertion, or set to something other than 'true',
 ###  the user is set as a non-administrator user.
 #SAML_ATTRIBUTE_ADMIN = 'https://example.edu/pdns-admin'
+
+## Attribute to get group from
+### Default: Don't use groups from SAML attribute
+### Example: https://example.edu/pdns-admin-group
+#SAML_ATTRIBUTE_GROUP = 'https://example.edu/pdns-admin'
+
+## Group namem to get admin status from
+### Default: Don't control admin with SAML group
+### Example: https://example.edu/pdns-admin
+#SAML_GROUP_ADMIN_NAME = 'powerdns-admin'
+
+## Attribute to get group to account mappings from
+### Default: None
+### If set, the user will be added and removed from accounts to match
+###  what's in the login assertion if they are in the required group
+#SAML_GROUP_TO_ACCOUNT_MAPPING = 'dev-admins=dev,prod-admins=prod'
 
 ## Attribute to get account names from
 ### Default: Don't control accounts with SAML attribute
@@ -95,6 +117,11 @@ SAML_SP_CONTACT_MAIL = '<contact mail>'
 #Configures if SAML tokens should be encrypted.
 #If enabled a new app certificate will be generated on restart
 SAML_SIGN_REQUEST = False
+
+# Configures if you want to request the IDP to sign the message
+# Default is True
+#SAML_WANT_MESSAGE_SIGNED = True
+
 #Use SAML standard logout mechanism retrieved from idp metadata
 #If configured false don't care about SAML session on logout.
 #Logout from PowerDNS-Admin only and keep SAML session authenticated.


### PR DESCRIPTION
Hi

I tried to integrate this with AzureAD and hit a few issues, 
I've made some changes to make this flow work better, let me know what you think

- Make SAML_WANT_MESSAGE_SIGNED configurable, AzureAD signs the assertion but wouldn't sign the message
- Add support for a name attribute, i.e. 'Tim Jacomb' using `SAML_ATTRIBUTE_NAME`, which will be mapped into the given and surname fields, AzureAD only has displayname
- Add support for group based admin `SAML_ATTRIBUTE_GROUP` and `SAML_GROUP_ADMIN_NAME`
- Add support for group based accounts `SAML_GROUP_TO_ACCOUNT_MAPPING`
- Don't fail if cert and key aren't present

I've updated the config_template.py

Didn't see anywhere where there was tests for this but let me know if you need me to update anywhere