### PR TITLE
escape special chars when creating group filter.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -171,7 +171,7 @@ class User(db.Model):
         whether a user is allowed to enter or not
         """
         LDAP_BASE_DN = Setting().get('ldap_base_dn')
-        groupSearchFilter = "(&(objectcategory=group)(member=%s))" % groupDN
+        groupSearchFilter = "(&(objectcategory=group)(member=%s))" % ldap.filter.escape_filter_chars(groupDN)
         result = [groupDN]
         try:
             groups = self.ldap_search(groupSearchFilter, LDAP_BASE_DN)


### PR DESCRIPTION
The LDAP search filter used for group queries needs to be escaped so that group names with special characters will not break the search filter in queries. e.g. a query for a group with a Common Name with parens will return 'Bad search filter' and break authentication.