### PR TITLE
Records entries must not make database requests for domain listing page

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1377,6 +1377,29 @@ class AccountUser(db.Model):
         return '<Account_User {0} {1}>'.format(self.account_id, self.user_id)
 
 
+class RecordEntry(object):
+    """
+    This is not a model, it's just an object
+    which will store records entries from PowerDNS API
+    """
+
+    def __init__(self, name=None, type=None, status=None, ttl=None, data=None,
+                 is_allowed_edit=False):
+        self.name = name
+        self.type = type
+        self.status = status
+        self.ttl = ttl
+        self.data = data
+        self._is_allowed_edit = is_allowed_edit
+        self._is_allowed_delete = is_allowed_edit and self.type != 'SOA'
+
+    def is_allowed_edit(self):
+        return self._is_allowed_edit
+
+    def is_allowed_delete(self):
+        return self._is_allowed_delete
+
+
 class Record(object):
 
     """

--- a/app/views.py
+++ b/app/views.py
@@ -18,7 +18,7 @@ from flask import g, request, make_response, jsonify, render_template, session, 
 from flask_login import login_user, logout_user, current_user, login_required
 from werkzeug import secure_filename
 
-from .models import User, Account, AccountUser, Domain, Record, Role, Server, History, Anonymous, Setting, DomainSetting, DomainTemplate, DomainTemplateRecord
+from .models import User, Account, AccountUser, Domain, Record, RecordEntry, Role, Server, History, Anonymous, Setting, DomainSetting, DomainTemplate, DomainTemplateRecord
 from app import app, login_manager, csrf
 from app.lib import utils
 from app.oauth import github_oauth, google_oauth, oidc_oauth
@@ -775,7 +775,7 @@ def domain(domain_name):
         for jr in jrecords:
             if jr['type'] in records_allow_to_edit:
                 for subrecord in jr['records']:
-                    record = Record(name=jr['name'], type=jr['type'], status='Disabled' if subrecord['disabled'] else 'Active', ttl=jr['ttl'], data=subrecord['content'])
+                    record = RecordEntry(name=jr['name'], type=jr['type'], status='Disabled' if subrecord['disabled'] else 'Active', ttl=jr['ttl'], data=subrecord['content'], is_allowed_edit=True)
                     records.append(record)
         if not re.search('ip6\.arpa|in-addr\.arpa$', domain_name):
             editable_records = forward_records_allow_to_edit
@@ -785,7 +785,7 @@ def domain(domain_name):
     else:
         for jr in jrecords:
             if jr['type'] in records_allow_to_edit:
-                record = Record(name=jr['name'], type=jr['type'], status='Disabled' if jr['disabled'] else 'Active', ttl=jr['ttl'], data=jr['content'])
+                record = RecordEntry(name=jr['name'], type=jr['type'], status='Disabled' if jr['disabled'] else 'Active', ttl=jr['ttl'], data=jr['content'], is_allowed_edit=True)
                 records.append(record)
     if not re.search('ip6\.arpa|in-addr\.arpa$', domain_name):
         editable_records = forward_records_allow_to_edit


### PR DESCRIPTION
When you want to display records for a domain, it will make 4 SQL requests for each records entry, to retrieve Settings fields which are not used at all in the domain page. This results in a really slow processing time, in our case for a zone with 4000 records, it will make 16000 queries.

This PR will create a new class just for storing records entries, which is sufficient for the domain page template.

Before this PR, the rendering of our 4000 records took 7 minutes, and now it only takes 4 seconds.