### PR TITLE
Standard compliant HTTP Response codes

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -19,7 +19,7 @@ class StructuredException(Exception):
 
 
 class DomainNotExists(StructuredException):
-    status_code = 1000
+    status_code = 404
 
     def __init__(self, name=None, message="Domain does not exist"):
         StructuredException.__init__(self)
@@ -28,7 +28,7 @@ class DomainNotExists(StructuredException):
 
 
 class DomainAccessForbidden(StructuredException):
-    status_code = 1001
+    status_code = 403
 
     def __init__(self, name=None, message="Domain access not allowed"):
         StructuredException.__init__(self)
@@ -37,7 +37,7 @@ class DomainAccessForbidden(StructuredException):
 
 
 class ApiKeyCreateFail(StructuredException):
-    status_code = 1002
+    status_code = 500
 
     def __init__(self, name=None, message="Creation of api key failed"):
         StructuredException.__init__(self)
@@ -46,7 +46,7 @@ class ApiKeyCreateFail(StructuredException):
 
 
 class ApiKeyNotUsable(StructuredException):
-    status_code = 1003
+    status_code = 400
 
     def __init__(self, name=None, message="Api key must have domains or have \
     administrative role"):
@@ -56,7 +56,7 @@ class ApiKeyNotUsable(StructuredException):
 
 
 class NotEnoughPrivileges(StructuredException):
-    status_code = 1004
+    status_code = 401
 
     def __init__(self, name=None, message="Not enough privileges"):
         StructuredException.__init__(self)
@@ -65,7 +65,7 @@ class NotEnoughPrivileges(StructuredException):
 
 
 class RequestIsNotJSON(StructuredException):
-    status_code = 1005
+    status_code = 400
 
     def __init__(self, name=None, message="Request is not json"):
         StructuredException.__init__(self)


### PR DESCRIPTION
Hello,

Presently the API returns non-standard complaint HTTP response codes. This causes reverse proxies such as Apache 2.4 to drop the responses:

[Thu Jun 27 18:23:12.684170 2019] [proxy_http:error] [pid 11733] (70014)End of file found: [client 216.19.183.221:53670] AH01102: error reading status line from remote server 127.0.0.1:8000
[Thu Jun 27 18:23:12.684611 2019] [proxy:error] [pid 11733] [client x.x.x.x:53670] AH00898: Error reading from remote server returned by /powerdns-admin/api/v1/pdnsadmin/apikeys

I'm proposing the following changes to the HTTP response codes, as I cannot see them being used anywhere else I don't think this should break any workflows.
