### PR TITLE
a Dockerfile for production run

### DIFF
--- a/docker/Production/Dockerfile
+++ b/docker/Production/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="k@ndk.name"
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
 
 RUN apt-get update -y \
-	&& apt-get install -y --no-install-recommends apt-transport-https locales locales-all python3-pip python3-setuptools python3-dev curl libsasl2-dev libldap2-dev libssl-dev libxml2-dev libxslt1-dev libxmlsec1-dev libffi-dev pkg-config build-essential libmariadb-dev-compat \
+	&& apt-get install -y --no-install-recommends apt-transport-https locales locales-all python3-pip python3-setuptools python3-dev curl libsasl2-dev libldap2-dev libssl-dev libxml2-dev libxslt1-dev libxmlsec1-dev libffi-dev build-essential libmariadb-dev-compat \
     && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \

--- a/docker/Production/Dockerfile
+++ b/docker/Production/Dockerfile
@@ -29,4 +29,4 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 ENV FLASK_APP=app/__init__.py
 EXPOSE 80/tcp
 ENTRYPOINT ["entrypoint.sh"]
-CMD ["gunicorn", "-t", "120", "--workers", "4", "--bind", "0.0.0.0:80", "--log-level", "info" ,"app:app"]
+CMD ["gunicorn","app:app"]

--- a/docker/Production/Dockerfile
+++ b/docker/Production/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:stretch-slim
+LABEL maintainer="k@ndk.name"
+
+ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
+
+RUN apt-get update -y \
+	&& apt-get install -y --no-install-recommends apt-transport-https locales locales-all python3-pip python3-dev curl libsasl2-dev libldap2-dev libssl-dev libxml2-dev libxslt1-dev libxmlsec1-dev libffi-dev pkg-config build-essential libmariadb-dev-compat \
+    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+    && apt-get install -y nodejs yarn \
+    && apt-get clean -y \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/powerdns-admin
+
+COPY . .
+RUN pip3 install -r requirements.txt \
+    && pip3 install psycopg2-binary \
+    && yarn install --pure-lockfile \
+    && flask assets build
+
+COPY ./docker/Production/entrypoint.sh /usr/local/bin/
+
+ENV FLASK_APP=app/__init__.py
+EXPOSE 80/tcp
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["gunicorn", "-t", "120", "--workers", "4", "--bind", "0.0.0.0:80", "--log-level", "info" ,"app:app"]

--- a/docker/Production/Dockerfile
+++ b/docker/Production/Dockerfile
@@ -24,6 +24,7 @@ RUN pip3 install -r requirements.txt \
     && rm config.py
 
 COPY ./docker/Production/entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENV FLASK_APP=app/__init__.py
 EXPOSE 80/tcp

--- a/docker/Production/Dockerfile
+++ b/docker/Production/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update -y \
     && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -y \
     && apt-get install -y nodejs yarn \
     && apt-get clean -y \
 	&& rm -rf /var/lib/apt/lists/*
@@ -17,7 +18,7 @@ WORKDIR /opt/powerdns-admin
 COPY . .
 RUN pip3 install -r requirements.txt \
     && pip3 install psycopg2-binary \
-    && yarn install \
+    && yarn install --pure-lockfile \
     && flask assets build
 
 COPY ./docker/Production/entrypoint.sh /usr/local/bin/

--- a/docker/Production/Dockerfile
+++ b/docker/Production/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt/powerdns-admin
 COPY . .
 RUN pip3 install -r requirements.txt \
     && pip3 install psycopg2-binary \
-    && yarn install --pure-lockfile \
+    && yarn install \
     && flask assets build
 
 COPY ./docker/Production/entrypoint.sh /usr/local/bin/

--- a/docker/Production/Dockerfile
+++ b/docker/Production/Dockerfile
@@ -19,7 +19,9 @@ COPY . .
 RUN pip3 install -r requirements.txt \
     && pip3 install psycopg2-binary \
     && yarn install --pure-lockfile \
-    && flask assets build
+    && cp config_template.py config.py \
+    && flask assets build \
+    && rm config.py
 
 COPY ./docker/Production/entrypoint.sh /usr/local/bin/
 

--- a/docker/Production/Dockerfile
+++ b/docker/Production/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="k@ndk.name"
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
 
 RUN apt-get update -y \
-	&& apt-get install -y --no-install-recommends apt-transport-https locales locales-all python3-pip python3-dev curl libsasl2-dev libldap2-dev libssl-dev libxml2-dev libxslt1-dev libxmlsec1-dev libffi-dev pkg-config build-essential libmariadb-dev-compat \
+	&& apt-get install -y --no-install-recommends apt-transport-https locales locales-all python3-pip python3-setuptools python3-dev curl libsasl2-dev libldap2-dev libssl-dev libxml2-dev libxslt1-dev libxmlsec1-dev libffi-dev pkg-config build-essential libmariadb-dev-compat \
     && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \

--- a/docker/Production/config_docker.py
+++ b/docker/Production/config_docker.py
@@ -1,3 +1,7 @@
+# defaults for Docker image
+BIND_ADDRESS='0.0.0.0'
+PORT=80
+
 legal_envvars = (
     'SECRET_KEY',
     'BIND_ADDRESS',

--- a/docker/Production/config_docker.py
+++ b/docker/Production/config_docker.py
@@ -1,0 +1,66 @@
+legal_envvars = (
+    'SECRET_KEY',
+    'BIND_ADDRESS',
+    'PORT',
+    'TIMEOUT',
+    'LOG_LEVEL',
+    'LOG_FILE',
+    'SALT',
+    'UPLOAD_DIR',
+    'SQLALCHEMY_TRACK_MODIFICATIONS',
+    'SQLALCHEMY_DATABASE_URI',
+    'SAML_ENABLED',
+    'SAML_DEBUG',
+    'SAML_PATH',
+    'SAML_METADATA_URL',
+    'SAML_METADATA_CACHE_LIFETIME',
+    'SAML_IDP_SSO_BINDING',
+    'SAML_IDP_ENTITY_ID',
+    'SAML_NAMEID_FORMAT',
+    'SAML_ATTRIBUTE_EMAIL',
+    'SAML_ATTRIBUTE_GIVENNAME',
+    'SAML_ATTRIBUTE_SURNAME',
+    'SAML_ATTRIBUTE_NAME',
+    'SAML_ATTRIBUTE_USERNAME',
+    'SAML_ATTRIBUTE_ADMIN',
+    'SAML_ATTRIBUTE_GROUP',
+    'SAML_GROUP_ADMIN_NAME',
+    'SAML_GROUP_TO_ACCOUNT_MAPPING',
+    'SAML_ATTRIBUTE_ACCOUNT',
+    'SAML_SP_ENTITY_ID',
+    'SAML_SP_CONTACT_NAME',
+    'SAML_SP_CONTACT_MAIL',
+    'SAML_SIGN_REQUEST',
+    'SAML_WANT_MESSAGE_SIGNED',
+    'SAML_LOGOUT',
+    'SAML_LOGOUT_URL',
+)
+
+legal_envvars_int = (
+    'PORT',
+    'TIMEOUT',
+    'SAML_METADATA_CACHE_LIFETIME',
+)
+
+legal_envvars_bool = (
+    'SQLALCHEMY_TRACK_MODIFICATIONS',
+    'SAML_ENABLED',
+    'SAML_DEBUG',
+    'SAML_SIGN_REQUEST',
+    'SAML_WANT_MESSAGE_SIGNED',
+    'SAML_LOGOUT',
+)
+
+# import everything from environment variables
+import os
+import sys
+for v in legal_envvars:
+    if v in os.environ:
+        ret = os.environ[v]
+        if v in legal_envvars_bool:
+            ret = bool(ret)
+        if v in legal_envvars_int:
+            ret = int(ret)
+        sys.modules[__name__].__dict__[v] = ret
+
+

--- a/docker/Production/entrypoint.sh
+++ b/docker/Production/entrypoint.sh
@@ -2,12 +2,19 @@
 set -Eeuo pipefail
 cd /opt/powerdns-admin
 
+GUNICORN_TIMEOUT="${GUINCORN_TIMEOUT:-120}"
+GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
+GUNICORN_LOGLEVEL="${GUNICORN_LOGLEVEL:-info}"
+
 if [ ! -f ./config.py ]; then
     cat ./config_template.py ./docker/Production/config_docker.py > ./config.py
 fi
 
+GUNICORN_ARGS="-t ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKERS} --bind 0.0.0.0:80 --log-level ${GUNICORN_LOGLEVEL}"
 if [ "$1" == gunicorn ]; then
     flask db upgrade
-fi
+    exec "$@" $GUNICORN_ARGS
 
-exec "$@"
+else
+    exec "$@"
+fi

--- a/docker/Production/entrypoint.sh
+++ b/docker/Production/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -Eeuo pipefail
+cd /opt/powerdns-admin
+
+DB_MIGRATION_DIR='./migrations'
+
+if [ ! -f ./config.py ]; then
+    cat ./config_template.py ./docker/Production/config_docker.py > ./config.py
+fi
+
+if [ "$1" == gunicorn ]; then
+    if [ ! -d "${DB_MIGRATION_DIR}" ]; then
+        flask db init --directory ${DB_MIGRATION_DIR}
+        flask db migrate -m "Init DB" --directory ${DB_MIGRATION_DIR}
+        flask db upgrade --directory ${DB_MIGRATION_DIR}
+        ./init_data.py
+    else
+        flask db migrate -m "Upgrade DB Schema" --directory ${DB_MIGRATION_DIR}
+        flask db upgrade --directory ${DB_MIGRATION_DIR}
+    fi
+fi
+
+exec "$@"

--- a/docker/Production/entrypoint.sh
+++ b/docker/Production/entrypoint.sh
@@ -2,22 +2,12 @@
 set -Eeuo pipefail
 cd /opt/powerdns-admin
 
-DB_MIGRATION_DIR='./migrations'
-
 if [ ! -f ./config.py ]; then
     cat ./config_template.py ./docker/Production/config_docker.py > ./config.py
 fi
 
 if [ "$1" == gunicorn ]; then
-    if [ ! -d "${DB_MIGRATION_DIR}" ]; then
-        flask db init --directory ${DB_MIGRATION_DIR}
-        flask db migrate -m "Init DB" --directory ${DB_MIGRATION_DIR}
-        flask db upgrade --directory ${DB_MIGRATION_DIR}
-        ./init_data.py
-    else
-        flask db migrate -m "Upgrade DB Schema" --directory ${DB_MIGRATION_DIR}
-        flask db upgrade --directory ${DB_MIGRATION_DIR}
-    fi
+    flask db upgrade
 fi
 
 exec "$@"


### PR DESCRIPTION
The current installation method is rather dirty and involves a lot of 3rd party tools. I wrote a Dockerfile for a clean installation of PowerDNS-Admin so it can be used in production with a clean environment. 

Usage for reference:

Create a env file `pdnsadmin-env`:
```
SECRET_KEY=your-very-secret-key
TIMEOUT=10
LOG_LEVEL=DEBUG
LOG_FILE=logfile.log
SALT=$2b$12$somerandomsalt
SQLALCHEMY_TRACK_MODIFICATIONS=True
SQLALCHEMY_DATABASE_URI=postgres://user:password@your.server.address:5432/database-name
```

Then run the prebuilt docker image:

```shell
docker run -p 9191:80 --env-file pdnsadmin-env jamesits/powerdns-admin:latest
```

Visit `http://localhost:9191` and you are ready to go.