### PR TITLE
forward get zones to real powerdns api

### DIFF
--- a/app/blueprints/api.py
+++ b/app/blueprints/api.py
@@ -504,8 +504,15 @@ def api_create_zone(server_id):
 @api_blueprint.route('/servers/<string:server_id>/zones', methods=['GET'])
 @apikey_auth
 def api_get_zones(server_id):
-    resp = helper.forward_request()
-    return resp.content, resp.status_code, resp.headers.items()
+    if server_id == 'powerdns':
+        if g.apikey.role.name not in ['Administrator', 'Operator']:
+            domain_obj_list = g.apikey.domains
+        else:
+            domain_obj_list = Domain.query.all()
+        return json.dumps(domain_schema.dump(domain_obj_list)), 200
+    else:
+        resp = helper.forward_request()
+        return resp.content, resp.status_code, resp.headers.items()
 
 
 #endpoint to snychronize Domains in background

--- a/app/blueprints/api.py
+++ b/app/blueprints/api.py
@@ -504,11 +504,9 @@ def api_create_zone(server_id):
 @api_blueprint.route('/servers/<string:server_id>/zones', methods=['GET'])
 @apikey_auth
 def api_get_zones(server_id):
-    if g.apikey.role.name not in ['Administrator', 'Operator']:
-        domain_obj_list = g.apikey.domains
-    else:
-        domain_obj_list = Domain.query.all()
-    return json.dumps(domain_schema.dump(domain_obj_list)), 200
+    resp = helper.forward_request()
+    return resp.content, resp.status_code, resp.headers.items()
+
 
 #endpoint to snychronize Domains in background
 @csrf.exempt

--- a/tests/unit/zone/test_admin_apikey.py
+++ b/tests/unit/zone/test_admin_apikey.py
@@ -80,7 +80,7 @@ class TestUnitApiZoneAdminApiKey(object):
             mock_get.return_value.status_code = 200
 
             res = client.get(
-                "/api/v1/servers/localhost/zones",
+                "/api/v1/servers/powerdns/zones",
                 headers=admin_apikey
             )
 
@@ -127,7 +127,7 @@ class TestUnitApiZoneAdminApiKey(object):
             mock_domain.query.all.return_value = [test_domain]
 
             res = client.get(
-                "/api/v1/servers/localhost/zones",
+                "/api/v1/servers/powerdns/zones",
                 headers=admin_apikey
             )
             data = res.get_json(force=True)

--- a/tests/unit/zone/test_user_apikey.py
+++ b/tests/unit/zone/test_user_apikey.py
@@ -108,7 +108,7 @@ class TestUnitApiZoneUserApiKey(object):
             mock_domain.query.all.return_value = [test_domain]
 
             res = client.get(
-                "/api/v1/servers/localhost/zones",
+                "/api/v1/servers/powerdns/zones",
                 headers=user_apikey
             )
             data = res.get_json(force=True)


### PR DESCRIPTION
There is already an endpoint which is correctly prefixed by /pdnsadmin so this one (/servers/<string:server_id>/zones) should correctly be forwarded to the real powerdns api.