### PR TITLE
Adjustment in domain's record applying

### DIFF
--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -5,7 +5,6 @@ import hashlib
 import ipaddress
 import os
 
-# from app import app
 from distutils.version import StrictVersion
 from urllib.parse import urlparse
 from datetime import datetime, timedelta
@@ -298,6 +297,10 @@ def validate_ipaddress(address):
         if isinstance(ip, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
             return [ip]
     return []
+
+
+def pretty_json(data):
+    return json.dumps(data, sort_keys=True, indent=4)
 
 
 class customBoxes:

--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -3,7 +3,6 @@ import traceback
 from flask import current_app
 from urllib.parse import urljoin
 from distutils.util import strtobool
-from distutils.version import StrictVersion
 
 from ..lib import utils
 from .base import db, domain_apikey
@@ -56,11 +55,6 @@ class Domain(db.Model):
         self.PDNS_API_KEY = Setting().get('pdns_api_key')
         self.PDNS_VERSION = Setting().get('pdns_version')
         self.API_EXTENDED_URL = utils.pdns_api_extended_uri(self.PDNS_VERSION)
-
-        if StrictVersion(self.PDNS_VERSION) >= StrictVersion('4.0.0'):
-            self.NEW_SCHEMA = True
-        else:
-            self.NEW_SCHEMA = False
 
     def __repr__(self):
         return '<Domain {0}>'.format(self.name)
@@ -214,9 +208,8 @@ class Domain(db.Model):
         headers = {}
         headers['X-API-Key'] = self.PDNS_API_KEY
 
-        if self.NEW_SCHEMA:
-            domain_name = domain_name + '.'
-            domain_ns = [ns + '.' for ns in domain_ns]
+        domain_name = domain_name + '.'
+        domain_ns = [ns + '.' for ns in domain_ns]
 
         if soa_edit_api not in ["DEFAULT", "INCREASE", "EPOCH", "OFF"]:
             soa_edit_api = 'DEFAULT'

--- a/powerdnsadmin/models/record.py
+++ b/powerdnsadmin/models/record.py
@@ -57,7 +57,7 @@ class Record(object):
             current_app.logger.error(
                 "Cannot fetch domain's record data from remote powerdns api. DETAIL: {0}"
                 .format(e))
-            return False
+            return []
 
         return jdata['rrsets']
 

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -183,7 +183,7 @@ def manage_user():
                 # Then delete the user
                 result = user.delete()
                 if result:
-                    history = History(msg='Delete username {0}'.format(data),
+                    history = History(msg='Delete user {0}'.format(data),
                                       created_by=current_user.username)
                     history.add()
                     return make_response(

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -1,4 +1,3 @@
-import re
 import json
 import traceback
 from ast import literal_eval

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -3,7 +3,7 @@ import json
 import traceback
 from ast import literal_eval
 from distutils.version import StrictVersion
-from flask import Blueprint, render_template, make_response, url_for, current_app, request, redirect, jsonify, abort
+from flask import Blueprint, render_template, make_response, url_for, current_app, request, redirect, jsonify, abort, flash
 from flask_login import login_required, current_user
 
 from ..decorators import operator_role_required, admin_role_required
@@ -843,7 +843,7 @@ def create_template_from_zone():
                     for jr in jrecords:
                         if jr['type'] in Setting().get_records_allow_to_edit():
                             name = '@' if jr['name'] == domain_name else re.sub(
-                                '\.{}$'.format(domain_name), '', jr['name'])
+                                r'\.{}$'.format(domain_name), '', jr['name'])
                             for subrecord in jr['records']:
                                 record = DomainTemplateRecord(
                                     name=name,
@@ -858,7 +858,7 @@ def create_template_from_zone():
                     for jr in jrecords:
                         if jr['type'] in Setting().get_records_allow_to_edit():
                             name = '@' if jr['name'] == domain_name else re.sub(
-                                '\.{}$'.format(domain_name), '', jr['name'])
+                                r'\.{}$'.format(domain_name), '', jr['name'])
                             record = DomainTemplateRecord(
                                 name=name,
                                 type=jr['type'],

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -168,7 +168,7 @@ def add():
                         record_row = {
                             'record_data': template_record.data,
                             'record_name': template_record.name,
-                            'record_status': template_record.status,
+                            'record_status': 'Active' if template_record.status else 'Disabled',
                             'record_ttl': template_record.ttl,
                             'record_type': template_record.type,
                             'comment_data': [{'content': template_record.comment, 'account': ''}]

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -5,6 +5,7 @@ from distutils.version import StrictVersion
 from flask import Blueprint, render_template, make_response, url_for, current_app, request, redirect, abort, jsonify
 from flask_login import login_required, current_user
 
+from ..lib.utils import pretty_json
 from ..decorators import can_create_domain, operator_role_required, can_access_domain, can_configure_dnssec
 from ..models.user import User
 from ..models.account import Account
@@ -27,17 +28,17 @@ domain_bp = Blueprint('domain',
 @login_required
 @can_access_domain
 def domain(domain_name):
-    r = Record()
+    # Validate the domain existing in the local DB
     domain = Domain.query.filter(Domain.name == domain_name).first()
     if not domain:
         abort(404)
 
-    # query domain info from PowerDNS API
-    zone_info = r.get_record_data(domain.name)
-    if zone_info:
-        jrecords = zone_info['records']
-    else:
-        # can not get any record, API server might be down
+    # Query domain's rrsets from PowerDNS API
+    rrsets = Record().get_rrsets(domain.name)
+    current_app.logger.debug("Fetched rrests: \n{}".format(pretty_json(rrsets)))
+
+    # API server might be down, misconfigured
+    if not rrsets:
         abort(500)
 
     quick_edit = Setting().get('record_quick_edit')
@@ -49,45 +50,40 @@ def domain(domain_name):
     ttl_options = Setting().get_ttl_options()
     records = []
 
+    # Render the "records" to display in HTML datatable
+    #
+    # BUG: If we have multiple records with the same name
+    # and each record has its own comment, the display of
+    # [record-comment] may not consistent because PDNS API
+    # returns the rrsets (records, comments) has different
+    # order than its database records.
+    # TODO:
+    #   - Find a way to make it consistent, or
+    #   - Only allow one comment for that case
     if StrictVersion(Setting().get('pdns_version')) >= StrictVersion('4.0.0'):
-        for jr in jrecords:
-            if jr['type'] in records_allow_to_edit:
-                for subrecord in jr['records']:
-                    record = RecordEntry(name=jr['name'],
-                                         type=jr['type'],
-                                         status='Disabled' if
-                                         subrecord['disabled'] else 'Active',
-                                         ttl=jr['ttl'],
-                                         data=subrecord['content'],
-                                         comment=jr['comment_data']['content'],
-                                         is_allowed_edit=True)
-                    records.append(record)
-        if not re.search('ip6\.arpa|in-addr\.arpa$', domain_name):
-            editable_records = forward_records_allow_to_edit
-        else:
-            editable_records = reverse_records_allow_to_edit
-        return render_template('domain.html',
-                               domain=domain,
-                               records=records,
-                               editable_records=editable_records,
-                               quick_edit=quick_edit,
-                               ttl_options=ttl_options)
+        for r in rrsets:
+            if r['type'] in records_allow_to_edit:
+                index = 0
+                for record in r['records']:
+                    record_entry = RecordEntry(
+                        name=r['name'].rstrip('.'),
+                        type=r['type'],
+                        status='Disabled' if record['disabled'] else 'Active',
+                        ttl=r['ttl'],
+                        data=record['content'],
+                        comment=r['comments'][index]['content'] if r['comments'] else '',
+                        is_allowed_edit=True)
+                    index += 1
+                    records.append(record_entry)
     else:
-        for jr in jrecords:
-            if jr['type'] in records_allow_to_edit:
-                record = RecordEntry(
-                    name=jr['name'],
-                    type=jr['type'],
-                    status='Disabled' if jr['disabled'] else 'Active',
-                    ttl=jr['ttl'],
-                    data=jr['content'],
-                    comment=jr['comment_data']['content'],
-                    is_allowed_edit=True)
-                records.append(record)
+        # Unsupported version
+        abort(500)
+
     if not re.search('ip6\.arpa|in-addr\.arpa$', domain_name):
         editable_records = forward_records_allow_to_edit
     else:
         editable_records = reverse_records_allow_to_edit
+
     return render_template('domain.html',
                            domain=domain,
                            records=records,
@@ -276,11 +272,11 @@ def change_type(domain_name):
     #TODO: Validate ip addresses input
     domain_master_ips = []
     if domain_type == 'slave' and request.form.getlist('domain_master_address'):
-            domain_master_string = request.form.getlist(
-                'domain_master_address')[0]
-            domain_master_string = domain_master_string.replace(
-                ' ', '')
-            domain_master_ips = domain_master_string.split(',')
+        domain_master_string = request.form.getlist(
+            'domain_master_address')[0]
+        domain_master_string = domain_master_string.replace(
+            ' ', '')
+        domain_master_ips = domain_master_string.split(',')
 
     d = Domain()
     status = d.update_kind(domain_name=domain_name,
@@ -354,19 +350,16 @@ def change_account(domain_name):
 @login_required
 @can_access_domain
 def record_apply(domain_name):
-    #TODO: filter removed records / name modified records.
-
     try:
         jdata = request.json
         submitted_serial = jdata['serial']
         submitted_record = jdata['record']
         domain = Domain.query.filter(Domain.name == domain_name).first()
-        current_app.logger.debug(
-            'Your submitted serial: {0}'.format(submitted_serial))
-        current_app.logger.debug('Current domain serial: {0}'.format(
-            domain.serial))
 
         if domain:
+            current_app.logger.debug('Current domain serial: {0}'.format(
+                domain.serial))
+
             if int(submitted_serial) != domain.serial:
                 return make_response(
                     jsonify({
@@ -384,26 +377,17 @@ def record_apply(domain_name):
                     'Domain name {0} does not exist'.format(domain_name)
                 }), 404)
 
-        # Modify the record's comment data. We append
-        # the "current_user" into account field as it
-        # a field with user-defined meaning
-        for sr in submitted_record:
-            if sr.get('record_comment'):
-                sr['comment_data'] = [{
-                    'content': sr['record_comment'],
-                    'account': current_user.username
-                }]
-            else:
-                sr['comment_data'] = []
-
         r = Record()
         result = r.apply(domain_name, submitted_record)
         if result['status'] == 'ok':
-            jdata.pop('_csrf_token',
-                      None)  # don't store csrf token in the history.
             history = History(
                 msg='Apply record changes to domain {0}'.format(domain_name),
-                detail=str(json.dumps(jdata)),
+                detail=str(
+                    json.dumps({
+                        "domain": domain_name,
+                        "add_rrests": result['data'][0]['rrsets'],
+                        "del_rrests": result['data'][1]['rrsets']
+                    })),
                 created_by=current_user.username)
             history.add()
             return make_response(jsonify(result), 200)

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -326,7 +326,6 @@ def signin_history(username, authenticator, success):
         request_ip = request.remote_addr
 
     # Write log
-    str_success = 'succeeded' if success else 'failed'
     if success:
         str_success = 'succeeded'
         current_app.logger.info(

--- a/powerdnsadmin/static/custom/js/custom.js
+++ b/powerdnsadmin/static/custom/js/custom.js
@@ -241,26 +241,30 @@ function reload_domains(url) {
 
 // pretty JSON
 json_library = {
-    replacer: function(match, pIndent, pKey, pVal, pEnd) {
+    replacer: function (match, pIndent, pKey, pVal, pEnd) {
         var key = '<span class=json-key>';
         var val = '<span class=json-value>';
         var str = '<span class=json-string>';
         var r = pIndent || '';
-        if (pKey){
-            r = r + key + pKey.replace(/[": ]/g, '') + '</span>: ';
+        if (pKey) {
+            // r = r + key + pKey.replace(/[": ]/g, '') + '</span>: ';
+            // Keep the quote in the key
+            r = r + key + pKey.replace(/":/, '"') + '</span>: ';
         }
-        if (pVal){
+        if (pVal) {
             r = r + (pVal[0] == '"' ? str : val) + pVal + '</span>';
         }
         return r + (pEnd || '');
     },
-    prettyPrint: function(obj) {
+    prettyPrint: function (obj) {
         obj = obj.replace(/u'/g, "\'").replace(/'/g, "\"").replace(/(False|None)/g, "\"$1\"");
         var jsonData = JSON.parse(obj);
-        var jsonLine = /^( *)("[\w]+": )?("[^"]*"|[\w.+-]*)?([,[{])?$/mg;
-            return JSON.stringify(jsonData, null, 3)
+        // var jsonLine = /^( *)("[\w]+": )?("[^"]*"|[\w.+-]*)?([,[{])?$/mg;
+        // The new regex to handle case value is an empty list [] or dict {}
+        var jsonLine = /^( *)("[\w]+": )?("[^"]*"|[\w.+-]*)?([,[{])?/mg;
+        return JSON.stringify(jsonData, null, 3)
             .replace(/&/g, '&amp;').replace(/\\"/g, '&quot;')
             .replace(/</g, '&lt;').replace(/>/g, '&gt;')
             .replace(jsonLine, json_library.replacer);
-        }
-    };
+    }
+};

--- a/powerdnsadmin/templates/dashboard.html
+++ b/powerdnsadmin/templates/dashboard.html
@@ -107,7 +107,7 @@
                           <td>{{ history.msg }}</td>
                           <td>{{ history.created_on }}</td>
                           <td width="6%">
-                              <button type="button" class="btn btn-flat btn-primary history-info-button" value='{{ history.detail|replace("[]","None") }}'>
+                              <button type="button" class="btn btn-flat btn-primary history-info-button" value='{{ history.detail }}'>
                                   Info&nbsp;<i class="fa fa-info"></i>
                               </button>
                           </td>

--- a/powerdnsadmin/templates/domain.html
+++ b/powerdnsadmin/templates/domain.html
@@ -335,6 +335,9 @@
                 mx_server = modal.find('#mx_server').val();
                 mx_priority = modal.find('#mx_priority').val();
                 data = mx_priority + " " + mx_server;
+                if (data && !data.endsWith('.')) {
+                    data = data + '.'
+                }
                 record_data.val(data);
                 modal.modal('hide');
             })
@@ -370,6 +373,9 @@
                 srv_port = modal.find('#srv_port').val();
                 srv_target = modal.find('#srv_target').val();
                 data = srv_priority + " " + srv_weight + " " + srv_port + " " + srv_target;
+                if (data && !data.endsWith('.')) {
+                    data = data + '.'
+                }
                 record_data.val(data);
                 modal.modal('hide');
             })

--- a/powerdnsadmin/templates/template_edit.html
+++ b/powerdnsadmin/templates/template_edit.html
@@ -313,6 +313,9 @@
                 mx_server = modal.find('#mx_server').val();
                 mx_priority = modal.find('#mx_priority').val();
                 data = mx_priority + " " + mx_server;
+                if (data && !data.endsWith('.')) {
+                    data = data + '.'
+                }
                 record_data.val(data);
                 modal.modal('hide');
             })
@@ -348,6 +351,9 @@
                 srv_port = modal.find('#srv_port').val();
                 srv_target = modal.find('#srv_target').val();
                 data = srv_priority + " " + srv_weight + " " + srv_port + " " + srv_target;
+                if (data && !data.endsWith('.')) {
+                    data = data + '.'
+                }
                 record_data.val(data);
                 modal.modal('hide');
             })

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,11 @@ datatables.net-bs@^1.10.19:
     datatables.net "1.10.19"
     jquery ">=1.7"
 
+datatables.net-plugins@^1.10.19:
+  version "1.10.20"
+  resolved "https://registry.yarnpkg.com/datatables.net-plugins/-/datatables.net-plugins-1.10.20.tgz#c89f6bed3fa7e6605cbeaa35d60f223659e84c8c"
+  integrity sha512-rnhNmRHe9UEzvM7gtjBay1QodkWUmxLUhHNbmJMYhhUggjtm+BRSlE0PRilkeUkwckpNWzq+0fPd7/i0fpQgzA==
+
 datatables.net@1.10.19, datatables.net@^1.10.19:
   version "1.10.19"
   resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.10.19.tgz#97a1ed41c85e62d61040603481b59790a172dd1f"


### PR DESCRIPTION
Change the way of submitting record changes from PDA to PDNS API. Create diffs (new records, deleted records) and submit to PDNS instead of sending all domain records data.

This will help:
- Send fewer data to PDNS API
- Keep the Record ID unchanged in PDNS database if it is not really updated. #526 
- Better displaying of "detail" in History feature. #354 #479 #590

TODO/Improvement:
- [ ] Comments belong to the `rrsets`. If we update record's comment, it will create a new rrset with `REPLACE` changetype => Should separate it from record's content change?
- [x] Drop PDNS 3.x support
- [x] History improvement
- [x] Bug fixes