### PR TITLE
Introduce PDNS_ADMIN_LOG_LEVEL to change the log level

### DIFF
--- a/powerdnsadmin/__init__.py
+++ b/powerdnsadmin/__init__.py
@@ -13,8 +13,12 @@ def create_app(config=None):
     from .assets import assets
     app = Flask(__name__)
 
+    # Read log level from environment variable
+    log_level_name = os.environ.get('PDNS_ADMIN_LOG_LEVEL', 'WARNING')
+    log_level = logging.getLevelName(log_level_name.upper())
     # Setting logger
     logging.basicConfig(
+       level=log_level,
         format=
         "[%(asctime)s] [%(filename)s:%(lineno)d] %(levelname)s - %(message)s")
 


### PR DESCRIPTION
By setting the environment variable PDNS_ADMIN_LOG_LEVEL to a Python
support log level, PowerDNS-Admin will use that log level.

If the environment variable is missing, `WARNING` will be used what is the current default.

I like to set the log level to info (which was the default in earlier versions) and with this change this is possible again.