### PR TITLE
Implement posixGroup support for LDAP auth

### DIFF
--- a/powerdnsadmin/models/setting.py
+++ b/powerdnsadmin/models/setting.py
@@ -44,7 +44,6 @@ class Setting(db.Model):
         'ldap_admin_username': '',
         'ldap_admin_password': '',
         'ldap_filter_basic': '',
-        'ldap_filter_group': '',
         'ldap_filter_username': '',
         'ldap_filter_groupname': '',
         'ldap_group_matching': 'groupOfNames',

--- a/powerdnsadmin/models/setting.py
+++ b/powerdnsadmin/models/setting.py
@@ -47,6 +47,7 @@ class Setting(db.Model):
         'ldap_filter_group': '',
         'ldap_filter_username': '',
         'ldap_filter_groupname': '',
+        'ldap_group_matching': 'groupOfNames',
         'ldap_sg_enabled': False,
         'ldap_admin_group': '',
         'ldap_operator_group': '',

--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -223,7 +223,7 @@ class User(db.Model):
             LDAP_BASE_DN = Setting().get('ldap_base_dn')
             LDAP_FILTER_BASIC = Setting().get('ldap_filter_basic')
             LDAP_FILTER_USERNAME = Setting().get('ldap_filter_username')
-            LDAP_FILTER_GROUP = Setting().get('ldap_filter_group')
+            LDAP_GROUP_MATCHING = Setting().get('ldap_group_matching')
             LDAP_FILTER_GROUPNAME = Setting().get('ldap_filter_groupname')
             LDAP_ADMIN_GROUP = Setting().get('ldap_admin_group')
             LDAP_OPERATOR_GROUP = Setting().get('ldap_operator_group')
@@ -271,10 +271,10 @@ class User(db.Model):
                     if LDAP_GROUP_SECURITY_ENABLED:
                         try:
                             if LDAP_TYPE == 'ldap':
-                                if Setting().get('ldap_group_matching') == "posixGroup":
-                                    groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, self.username, LDAP_FILTER_GROUP)
+                                if LDAP_GROUP_MATCHING == "posixGroup":
+                                    groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, self.username, "(objectClass=posixGroup)")
                                 else:
-                                    groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, ldap_username, LDAP_FILTER_GROUP)
+                                    groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, ldap_username, "(objectClass=groupOfNames)")
                                 current_app.logger.debug('Ldap groupSearchFilter {0}'.format(groupSearchFilter))
                                 if (self.ldap_search(groupSearchFilter,
                                                      LDAP_ADMIN_GROUP)):

--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -271,7 +271,10 @@ class User(db.Model):
                     if LDAP_GROUP_SECURITY_ENABLED:
                         try:
                             if LDAP_TYPE == 'ldap':
-                                groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, ldap_username, LDAP_FILTER_GROUP)
+                                if Setting().get('ldap_group_matching') == "posixGroup":
+                                    groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, self.username, LDAP_FILTER_GROUP)
+                                else:
+                                    groupSearchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_GROUPNAME, ldap_username, LDAP_FILTER_GROUP)
                                 current_app.logger.debug('Ldap groupSearchFilter {0}'.format(groupSearchFilter))
                                 if (self.ldap_search(groupSearchFilter,
                                                      LDAP_ADMIN_GROUP)):

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -651,8 +651,6 @@ def setting_authentication():
                               request.form.get('ldap_admin_password'))
                 Setting().set('ldap_filter_basic',
                               request.form.get('ldap_filter_basic'))
-                Setting().set('ldap_filter_group',
-                              request.form.get('ldap_filter_group'))
                 Setting().set('ldap_filter_username',
                               request.form.get('ldap_filter_username'))
                 Setting().set('ldap_filter_groupname',

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -657,6 +657,8 @@ def setting_authentication():
                               request.form.get('ldap_filter_username'))
                 Setting().set('ldap_filter_groupname',
                               request.form.get('ldap_filter_groupname'))
+                Setting().set('ldap_group_matching',
+                              request.form.get('ldap_group_matching'))
                 Setting().set(
                     'ldap_sg_enabled', True
                     if request.form.get('ldap_sg_enabled') == 'ON' else False)

--- a/powerdnsadmin/templates/admin_setting_authentication.html
+++ b/powerdnsadmin/templates/admin_setting_authentication.html
@@ -143,12 +143,22 @@
                                                     <input type="text" class="form-control" name="ldap_filter_username" id="ldap_filter_username" placeholder="e.g. uid" data-error="Please input field for username filtering" value="{{ SETTING.get('ldap_filter_username') }}">
                                                     <span class="help-block with-errors"></span>
                                                 </div>
-                                                <div id="ldap_openldap_group_filters">
-                                                    <div class="form-group">
-                                                        <label for="ldap_filter_group">Group filter</label>
-                                                        <input type="text" class="form-control" name="ldap_filter_group" id="ldap_filter_group" placeholder="e.g. (objectclass=groupOfNames)" data-error="Please input LDAP filter" value="{{ SETTING.get('ldap_filter_group') }}">
-                                                        <span class="help-block with-errors"></span>
+                                            </fieldset>
+                                            <fieldset>
+                                                <legend>GROUP SECURITY</legend>
+                                                <div class="form-group">
+                                                    <label>Status</label>
+                                                    <div class="radio">
+                                                        <label>
+                                                            <input type="radio" name="ldap_sg_enabled" id="ldap_sg_off" value="OFF" {% if not SETTING.get('ldap_sg_enabled') %}checked{% endif %}> OFF
+                                                        </label>
+                                                        &nbsp;&nbsp;&nbsp;
+                                                        <label>
+                                                            <input type="radio" name="ldap_sg_enabled" id="ldap_sg_on" value="ON" {% if SETTING.get('ldap_sg_enabled') %}checked{% endif %}> ON
+                                                        </label>
                                                     </div>
+                                                </div>
+                                                <div id="ldap_openldap_group_filters">
                                                     <label>Group member matching</label>
                                                     <div class="radio">
                                                         <label>
@@ -163,21 +173,6 @@
                                                         <label for="ldap_filter_groupname">Group name field</label>
                                                         <input type="text" class="form-control" name="ldap_filter_groupname" id="ldap_filter_groupname" placeholder="e.g. member" data-error="Please input field for group name filtering" value="{{ SETTING.get('ldap_filter_groupname') }}">
                                                         <span class="help-block with-errors"></span>
-                                                    </div>
-                                                </div>
-                                            </fieldset>
-                                            <fieldset>
-                                                <legend>GROUP SECURITY</legend>
-                                                <div class="form-group">
-                                                    <label>Status</label>
-                                                    <div class="radio">
-                                                        <label>
-                                                            <input type="radio" name="ldap_sg_enabled" id="ldap_sg_off" value="OFF" {% if not SETTING.get('ldap_sg_enabled') %}checked{% endif %}> OFF
-                                                        </label>
-                                                        &nbsp;&nbsp;&nbsp;
-                                                        <label>
-                                                            <input type="radio" name="ldap_sg_enabled" id="ldap_sg_on" value="ON" {% if SETTING.get('ldap_sg_enabled') %}checked{% endif %}> ON
-                                                        </label>
                                                     </div>
                                                 </div>
                                                 <div class="form-group">
@@ -246,15 +241,6 @@
                                                     <li>
                                                         Username field - The field PDA will look for user's username. (e.g. <i>uid</i> for OpenLDAP and <i>sAMAccountName</i> for Active Directory)
                                                     </li>
-                                                    <li>
-                                                        Group filter - The filter that will be applied to all LDAP group queries by PDA. (e.g. <i>(objectClass=groupOfNames)</i> for OpenLDAP)
-                                                    </li>
-                                                    <li>
-                                                        Group member matching - The field to choose between wether to use <i>groupOfNames</i> or <i>posixGroup</i> group membership matching.
-                                                    </li>
-                                                    <li>
-                                                        Group name field - The field PDA will look for group names. (e.g. <i>member</i> for OpenLDAP with groupOfNames support or <i>memberUid</i> with posixGroup matching)
-                                                    </li>
                                                 </ul>
                                             </dd>
                                             <dt>GROUP SECURITY</dt>
@@ -262,6 +248,12 @@
                                                 <ul>
                                                     <li>
                                                         Status - Turn on / off group security feature.
+                                                    </li>
+                                                    <li>
+                                                        Group member matching - The field to choose between wether to use <i>groupOfNames</i> or <i>posixGroup</i> group membership matching.
+                                                    </li>
+                                                    <li>
+                                                        Group name field - The field PDA will look for group names. (e.g. <i>member</i> for OpenLDAP with groupOfNames support or <i>memberUid</i> with posixGroup matching)
                                                     </li>
                                                     <li>
                                                         Admin group - Your LDAP admin group.
@@ -609,7 +601,6 @@
                 $('#ldap_domain').prop('required', true);
             }
             $('#ldap_filter_basic').prop('required', true);
-            $('#ldap_filter_group').prop('required', true);
             $('#ldap_filter_username').prop('required', true);
             $('#ldap_filter_groupname').prop('required', true);
             $('#ldap_group_matching').prop('required', true);
@@ -626,7 +617,6 @@
             $('#ldap_admin_username').prop('required', false);
             $('#ldap_admin_password').prop('required', false);
             $('#ldap_filter_basic').prop('required', false);
-            $('#ldap_filter_group').prop('required', false);
             $('#ldap_filter_username').prop('required', false);
             $('#ldap_filter_groupname').prop('required', false);
             $('#ldap_group_matching').prop('required', false);
@@ -679,7 +669,6 @@
             $('#ldap_domain').prop('required', true);
         }
         $('#ldap_filter_basic').prop('required', true);
-        $('#ldap_filter_group').prop('required', true);
         $('#ldap_filter_username').prop('required', true);
         $('#ldap_filter_groupname').prop('required', true);
         $('#ldap_group_matching').prop('required', true);

--- a/powerdnsadmin/templates/admin_setting_authentication.html
+++ b/powerdnsadmin/templates/admin_setting_authentication.html
@@ -149,6 +149,16 @@
                                                         <input type="text" class="form-control" name="ldap_filter_group" id="ldap_filter_group" placeholder="e.g. (objectclass=groupOfNames)" data-error="Please input LDAP filter" value="{{ SETTING.get('ldap_filter_group') }}">
                                                         <span class="help-block with-errors"></span>
                                                     </div>
+                                                    <label>Group member matching</label>
+                                                    <div class="radio">
+                                                        <label>
+                                                            <input type="radio" name="ldap_group_matching" id="ldap_gr_match_groupofnames" value="groupOfNames" {% if SETTING.get('ldap_group_matching') == "groupOfNames" %}checked{% endif %}> groupOfNames
+                                                        </label>
+                                                        &nbsp;&nbsp;&nbsp;
+                                                        <label>
+                                                            <input type="radio" name="ldap_group_matching" id="ldap_gr-match_posixgroup" value="posixGroup" {% if SETTING.get('ldap_group_matching') == "posixGroup" %}checked{% endif %}> posixGroup
+                                                        </label>
+                                                    </div>
                                                     <div class="form-group">
                                                         <label for="ldap_filter_groupname">Group name field</label>
                                                         <input type="text" class="form-control" name="ldap_filter_groupname" id="ldap_filter_groupname" placeholder="e.g. member" data-error="Please input field for group name filtering" value="{{ SETTING.get('ldap_filter_groupname') }}">
@@ -240,7 +250,10 @@
                                                         Group filter - The filter that will be applied to all LDAP group queries by PDA. (e.g. <i>(objectClass=groupOfNames)</i> for OpenLDAP)
                                                     </li>
                                                     <li>
-                                                        Group name field - The field PDA will look for group names. (e.g. <i>member</i> for OpenLDAP)
+                                                        Group member matching - The field to choose between wether to use <i>groupOfNames</i> or <i>posixGroup</i> group membership matching.
+                                                    </li>
+                                                    <li>
+                                                        Group name field - The field PDA will look for group names. (e.g. <i>member</i> for OpenLDAP with groupOfNames support or <i>memberUid</i> with posixGroup matching)
                                                     </li>
                                                 </ul>
                                             </dd>
@@ -599,6 +612,7 @@
             $('#ldap_filter_group').prop('required', true);
             $('#ldap_filter_username').prop('required', true);
             $('#ldap_filter_groupname').prop('required', true);
+            $('#ldap_group_matching').prop('required', true);
 
             if ($('#ldap_sg_on').is(":checked")) {
                 $('#ldap_admin_group').prop('required', true);
@@ -615,6 +629,7 @@
             $('#ldap_filter_group').prop('required', false);
             $('#ldap_filter_username').prop('required', false);
             $('#ldap_filter_groupname').prop('required', false);
+            $('#ldap_group_matching').prop('required', false);
 
             if ($('#ldap_sg_on').is(":checked")) {
                 $('#ldap_admin_group').prop('required', false);
@@ -667,6 +682,7 @@
         $('#ldap_filter_group').prop('required', true);
         $('#ldap_filter_username').prop('required', true);
         $('#ldap_filter_groupname').prop('required', true);
+        $('#ldap_group_matching').prop('required', true);
 
         if ($('#ldap_sg_on').is(":checked")) {
             $('#ldap_admin_group').prop('required', true);


### PR DESCRIPTION
As described in #513 this implements support for the LDAP group member matching by posixGroup instead of the groupOfNames membership identification.

Screenshot of the filters section:
![PDA_ldap-posixGroup-support](https://user-images.githubusercontent.com/6536990/74100233-c42ab980-4b2c-11ea-8e0a-73b0f7e0759f.png)