### PR TITLE
Bug: Creating multiple records with single comment

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -105,7 +105,7 @@ def domain(domain_name):
                         status='Disabled' if record['disabled'] else 'Active',
                         ttl=r['ttl'],
                         data=record['content'],
-                        comment=r['comments'][index]['content']
+                        comment=r['comments'][0]['content']
                         if r['comments'] else '',
                         is_allowed_edit=True)
                     index += 1


### PR DESCRIPTION
We encountered an issue when creating multiple records of the same name with different data.  The code block which executes to create multiple RecordEntry objects was attempting to use the incremented index value despite the fact that there is only ever a single comment associated with the records.

Hard-coding this to the first element corrected the failure and was an effective fix for our use cases.
