### PR TITLE
Correct request method

### DIFF
--- a/powerdnsadmin/lib/helper.py
+++ b/powerdnsadmin/lib/helper.py
@@ -28,7 +28,7 @@ def forward_request():
         'X-API-KEY': pdns_api_key
     }
 
-    url = urljoin(pdns_api_url, request.path)
+    url = urljoin(pdns_api_url, request.full_path)
 
     resp = requests.request(request.method,
                             url,


### PR DESCRIPTION
I recently opened this issue: https://github.com/ngoduykhanh/PowerDNS-Admin/issues/666

I've found the issue, the method of flask "request" in order to call de pdns api with the parameter is request.full_path rather than request.path in the file helper.py.

I hope this pull request be useful.

Regards.