### PR TITLE
Fix token name in session for OIDC and GitHub authentication

### DIFF
--- a/powerdnsadmin/services/github.py
+++ b/powerdnsadmin/services/github.py
@@ -12,7 +12,7 @@ def github_oauth():
         return session.get('github_token')
 
     def update_token(token):
-        session['google_token'] = token
+        session['github_token'] = token
         return token
 
     github = authlib_oauth_client.register(

--- a/powerdnsadmin/services/oidc.py
+++ b/powerdnsadmin/services/oidc.py
@@ -12,7 +12,7 @@ def oidc_oauth():
         return session.get('oidc_token')
 
     def update_token(token):
-        session['google_token'] = token
+        session['oidc_token'] = token
         return token
 
     oidc = authlib_oauth_client.register(


### PR DESCRIPTION
Seems like typos during code refactoring.
I didn't test the changes but I think now it's better than before with setting wrong token names in the session.