### PR TITLE
Remove blank comments from rrsets before sending for compatibility

### DIFF
--- a/powerdnsadmin/models/record.py
+++ b/powerdnsadmin/models/record.py
@@ -272,6 +272,15 @@ class Record(object):
         # Get the list of rrsets to be added and deleted
         new_rrsets, del_rrsets = self.compare(domain_name, submitted_records)
 
+        # Remove blank comments from rrsets for compatability with some backends
+        for r in new_rrsets['rrsets']:
+            if not r['comments']:
+                del r['comments']
+
+        for r in del_rrsets['rrsets']:
+            if not r['comments']:
+                del r['comments']
+
         # Submit the changes to PDNS API
         try:
             headers = {}


### PR DESCRIPTION
As per #676 when submitting changes to a backends that doesn't support comments the api call will fail. This is really only an issue with the [LMDB backend](https://doc.powerdns.com/authoritative/backends/lmdb.html) as most of the other traditional backends support comments. 

I propose removing the comments field from the api request if the comment is blank. This should allow the request to succeed if the backend supports it and gives a clear error if it fails. 
![image](https://user-images.githubusercontent.com/15354012/76140134-de1cc680-601c-11ea-8550-e9e226c1ebb8.png)

I refrained from creating a setting to remove comments as it would silently delete them without notifying the user. Full disclosure I haven't tested this on other backends. This was a quick fix, so suggestions are welcome. 
