### PR TITLE
Remove $SCRIPT_ROOT from 'admin.create_template_from_zone' URL

### DIFF
--- a/powerdnsadmin/templates/dashboard.html
+++ b/powerdnsadmin/templates/dashboard.html
@@ -251,7 +251,7 @@
             data['name'] = modal.find('#template_name').val();
             data['description'] = modal.find('#template_description').val();
             data['domain'] = modal.find('#domain').val();
-            applyChanges(data, $SCRIPT_ROOT + "{{ url_for('admin.create_template_from_zone') }}", true);
+            applyChanges(data, "{{ url_for('admin.create_template_from_zone') }}", true);
             modal.modal('hide');
         })
         modal.find('#button_close').click(function() {


### PR DESCRIPTION
As the URL here is contructed from Flask's "url_for" which already
takes the script root into account, we do not need to add it here
explicitly. This would result in a duplicate script root otherwise.