### PR TITLE
Workaround for comment(s) on multiple records for the same name/type

### DIFF
--- a/powerdnsadmin/__init__.py
+++ b/powerdnsadmin/__init__.py
@@ -45,6 +45,15 @@ def create_app(config=None):
     csrf.exempt(routes.api.api_zone_subpath_forward)
     csrf.exempt(routes.api.api_zone_forward)
     csrf.exempt(routes.api.api_create_zone)
+    csrf.exempt(routes.api.api_create_account)
+    csrf.exempt(routes.api.api_delete_account)
+    csrf.exempt(routes.api.api_update_account)
+    csrf.exempt(routes.api.api_create_user)
+    csrf.exempt(routes.api.api_delete_user)
+    csrf.exempt(routes.api.api_update_user)
+    csrf.exempt(routes.api.api_list_account_users)
+    csrf.exempt(routes.api.api_add_account_user)
+    csrf.exempt(routes.api.api_remove_account_user)
 
     # Load config from env variables if using docker
     if os.path.exists(os.path.join(app.root_path, 'docker_config.py')):

--- a/powerdnsadmin/decorators.py
+++ b/powerdnsadmin/decorators.py
@@ -161,6 +161,41 @@ def is_json(f):
     return decorated_function
 
 
+def api_role_can(action, roles=None, allow_self=False):
+    """
+    Grant access if:
+        - user is in the permitted roles
+        - allow_self and kwargs['user_id'] = current_user.id
+        - allow_self and kwargs['username'] = current_user.username
+    """
+    if roles is None:
+        roles = ['Administrator', 'Operator']
+
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            try:
+                user_id = int(kwargs.get('user_id'))
+            except:
+                user_id = None
+            try:
+                username = kwargs.get('username')
+            except:
+                username = None
+            if (
+                (current_user.role.name in roles) or
+                (allow_self and user_id and current_user.id == user_id) or
+                (allow_self and username and current_user.username == username)
+            ):
+                return f(*args, **kwargs)
+            msg = (
+                "User {} with role {} does not have enough privileges to {}"
+            ).format(current_user.username, current_user.role.name, action)
+            raise NotEnoughPrivileges(message=msg)
+        return decorated_function
+    return decorator
+
+
 def api_can_create_domain(f):
     """
     Grant access if:

--- a/powerdnsadmin/lib/errors.py
+++ b/powerdnsadmin/lib/errors.py
@@ -82,3 +82,57 @@ class RequestIsNotJSON(StructuredException):
         StructuredException.__init__(self)
         self.message = message
         self.name = name
+
+
+class AccountCreateFail(StructuredException):
+    status_code = 500
+
+    def __init__(self, name=None, message="Creation of account failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name
+
+
+class AccountUpdateFail(StructuredException):
+    status_code = 500
+
+    def __init__(self, name=None, message="Update of account failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name
+
+
+class AccountDeleteFail(StructuredException):
+    status_code = 500
+
+    def __init__(self, name=None, message="Delete of account failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name
+
+
+class UserCreateFail(StructuredException):
+    status_code = 500
+
+    def __init__(self, name=None, message="Creation of user failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name
+
+
+class UserUpdateFail(StructuredException):
+    status_code = 500
+
+    def __init__(self, name=None, message="Update of user failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name
+
+
+class UserDeleteFail(StructuredException):
+    status_code = 500
+
+    def __init__(self, name=None, message="Delete of user failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name

--- a/powerdnsadmin/lib/helper.py
+++ b/powerdnsadmin/lib/helper.py
@@ -28,7 +28,7 @@ def forward_request():
         'X-API-KEY': pdns_api_key
     }
 
-    url = urljoin(pdns_api_url, request.path)
+    url = urljoin(pdns_api_url, request.full_path)
 
     resp = requests.request(request.method,
                             url,

--- a/powerdnsadmin/lib/schema.py
+++ b/powerdnsadmin/lib/schema.py
@@ -25,3 +25,21 @@ class ApiPlainKeySchema(Schema):
     domains = fields.Embed(schema=DomainSchema, many=True)
     description = fields.String()
     plain_key = fields.String()
+
+
+class UserSchema(Schema):
+    id = fields.Integer()
+    username = fields.String()
+    firstname = fields.String()
+    lastname = fields.String()
+    email = fields.String()
+    role = fields.Embed(schema=RoleSchema)
+
+
+class AccountSchema(Schema):
+    id = fields.Integer()
+    name = fields.String()
+    description = fields.String()
+    contact = fields.String()
+    mail = fields.String()
+    domains = fields.Embed(schema=DomainSchema, many=True)

--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -50,8 +50,9 @@ def fetch_remote(remote_url,
                          timeout=timeout,
                          data=data,
                          params=params)
-    logging.debug('Querying remote server "{0}" ({1}) finished with code {2} (took {3:.3f}s)'.format(
-        remote_url, method, r.status_code, r.elapsed.total_seconds()))
+    logging.debug(
+        'Querying remote server "{0}" ({1}) finished with code {2} (took {3}s)'
+        .format(remote_url, method, r.status_code, r.elapsed.total_seconds()))
     try:
         if r.status_code not in (200, 201, 204, 400, 409, 422):
             r.raise_for_status()

--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import json
 import requests
@@ -49,6 +50,8 @@ def fetch_remote(remote_url,
                          timeout=timeout,
                          data=data,
                          params=params)
+    logging.debug('Querying remote server "{0}" ({1}) finished with code {2} (took {3:.3f}s)'.format(
+        remote_url, method, r.status_code, r.elapsed.total_seconds()))
     try:
         if r.status_code not in (200, 201, 204, 400, 409, 422):
             r.raise_for_status()

--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -57,7 +57,7 @@ def fetch_remote(remote_url,
         if r.status_code not in (200, 201, 204, 400, 409, 422):
             r.raise_for_status()
     except Exception as e:
-        msg = "Returned status {0} and content {1}"
+        msg = "Returned status {0} and content {1}".format(r.status_code, r.text)
         raise RuntimeError('Error while fetching {0}. {1}'.format(
             remote_url, msg))
 

--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -99,14 +99,19 @@ def domain(domain_name):
                 # PDA jinja2 template can understand.
                 index = 0
                 for record in r['records']:
+                    try:
+                        comment = ''
+                        comment = r['comments'][0]['content']
+                        comment = r['comments'][index]['content']
+                    except (KeyError, IndexError):
+                        pass
                     record_entry = RecordEntry(
                         name=r_name,
                         type=r['type'],
                         status='Disabled' if record['disabled'] else 'Active',
                         ttl=r['ttl'],
                         data=record['content'],
-                        comment=r['comments'][index]['content']
-                        if r['comments'] else '',
+                        comment=comment,
                         is_allowed_edit=True)
                     index += 1
                     records.append(record_entry)

--- a/powerdnsadmin/services/azure.py
+++ b/powerdnsadmin/services/azure.py
@@ -11,6 +11,10 @@ def azure_oauth():
     def fetch_azure_token():
         return session.get('azure_token')
 
+    def update_token(token):
+        session['azure_token'] = token
+        return token
+
     azure = authlib_oauth_client.register(
         'azure',
         client_id=Setting().get('azure_oauth_key'),
@@ -33,6 +37,6 @@ def azure_oauth():
             return 'Access denied: reason=%s error=%s' % (
                 request.args['error'], request.args['error_description'])
         session['azure_token'] = (token)
-        return redirect(url_for('.login', _external=True, _scheme='https'))
+        return redirect(url_for('index.login', _external=True, _scheme='https'))
 
     return azure

--- a/powerdnsadmin/services/github.py
+++ b/powerdnsadmin/services/github.py
@@ -12,7 +12,7 @@ def github_oauth():
         return session.get('github_token')
 
     def update_token(token):
-        session['google_token'] = token
+        session['github_token'] = token
         return token
 
     github = authlib_oauth_client.register(

--- a/powerdnsadmin/services/oidc.py
+++ b/powerdnsadmin/services/oidc.py
@@ -12,7 +12,7 @@ def oidc_oauth():
         return session.get('oidc_token')
 
     def update_token(token):
-        session['google_token'] = token
+        session['oidc_token'] = token
         return token
 
     oidc = authlib_oauth_client.register(

--- a/powerdnsadmin/swagger-spec.yaml
+++ b/powerdnsadmin/swagger-spec.yaml
@@ -963,6 +963,424 @@ paths:
           description: 'Internal Server Error. Contains error message'
           schema:
             $ref: '#/definitions/Error'
+  '/pdnsadmin/users':
+    get:
+      security:
+        - basicAuth: []
+      summary: 'Get all User entries'
+      operationId: api_list_users
+      tags:
+        - user
+      responses:
+        '200':
+          description: List of User objects
+          schema:
+            type: array
+            items:
+              $ref: #/definitions/User
+        '500':
+          description: Internal Server Error, users could not be retrieved. Contains error message
+          schema:
+            $ref: #/definitions/Error
+    post:
+      security:
+        - basicAuth: []
+      summary: Add a User
+      description: This methods adds a new User
+      operationId: api_create_user
+      tags:
+        - user
+      parameters:
+        - name: username
+          description: Login name for user (unique, immutable)
+          required: true
+          in: body
+        - name: password
+          description: Hashed password for authentication
+          required: false
+          in: body
+        - name: plain_text_password
+          description: Plain text password (will be hashed) for authentication
+          required: false
+          in: body
+        - name: firstname
+          description: Firstname of user
+          required: false
+          in: body
+        - name: lastname
+          description: Lastname of user
+          required: false
+          in: body
+        - name: email
+          description: Email address if user (must be unique)
+          required: true
+          in: body
+        - name: otp_secret
+          description: OTP secret
+          required: false
+          in: body
+        - name: confirmed
+          description: Confirmed status
+          required: false
+          in: body
+        - name: role_name
+          description: Name of role to be assigned to user (default 'User')
+          required: false
+          in: body
+        - name: role_id
+          description: Role ID of role to be assigned to user
+          required: false
+          in: body
+      responses:
+        '201':
+          description: Created
+          schema:
+            $ref: #/definitions/User
+        '400':
+          description: Unprocessable Entry, the User data provided has issues
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error. There was a problem creating the user
+          schema:
+            $ref: #/definitions/Error
+  '/pdnsadmin/users/{username}':
+    parameters:
+      - name: username
+        type: string
+        in: path
+        required: true
+        description: The username of the user to retrieve
+    get:
+      security:
+        - basicAuth: []
+      summary: Get a specific User on the server
+      operationId: api_list_users
+      tags:
+        - user
+      responses:
+        '200':
+          description: Retrieve a specific User
+          schema:
+            $ref: #/definitions/User
+        '404':
+          description: Not found. The User with the specified username does not exist
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error, user could not be retrieved. Contains error message
+          schema:
+            $ref: #/definitions/Error
+  '/pdnsadmin/users/{user_id}':
+    parameters:
+      - name: user_id
+        type: integer
+        in: path
+        required: true
+        description: The id of the user to modify or delete
+    put:
+      security:
+        - basicAuth: []
+      summary: Modify a specific User on the server with supplied parameters
+      operationId: api_update_user
+      tags:
+        - user
+      parameters:
+        - name: username
+          description: Login name for user (unique, immutable)
+          required: false
+          in: body
+        - name: password
+          description: Hashed password for authentication
+          required: false
+          in: body
+        - name: plain_text_password
+          description: Plain text password (will be hashed) for authentication
+          required: false
+          in: body
+        - name: firstname
+          description: Firstname of user
+          required: false
+          in: body
+        - name: lastname
+          description: Lastname of user
+          required: false
+          in: body
+        - name: email
+          description: Email address if user (must be unique)
+          required: false
+          in: body
+        - name: otp_secret
+          description: OTP secret
+          required: false
+          in: body
+        - name: confirmed
+          description: Confirmed status
+          required: false
+          in: body
+        - name: role_name
+          description: Name of role to be assigned to user (default 'User')
+          required: false
+          in: body
+        - name: role_id
+          description: Role id of role to be assigned to user
+          required: false
+          in: body
+      responses:
+        '204':
+          description: OK. User is modified (empty response body)
+        '404':
+          description: Not found. The User with the specified user_id does not exist
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error. Contains error message
+          schema:
+            $ref: #/definitions/Error
+    delete:
+      security:
+        - basicAuth: []
+      summary: Delete a specific User
+      operationId: api_delete_user
+      tags:
+        - user
+      responses:
+        '204':
+          description: OK. User is deleted (empty response body)
+        '404':
+          description: Not found. The User with the specified user_id does not exist
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error. Contains error message
+          schema:
+            $ref: #/definitions/Error
+  '/pdnsadmin/accounts':
+    get:
+      security:
+        - basicAuth: []
+      summary: Get all Account entries
+      operationId: api_list_accounts
+      tags:
+        - account
+      responses:
+        '200':
+          description: List of Account objects
+          schema:
+            type: array
+            items:
+              $ref: #/definitions/Account
+        '500':
+          description: Internal Server Error, accounts could not be retrieved. Contains error message
+          schema:
+            $ref: #/definitions/Error
+    post:
+      security:
+        - basicAuth: []
+      summary: Add an Account
+      description: This methods adds a new Account
+      operationId: api_create_account
+      tags:
+        - account
+      parameters:
+        - name: name
+          description: Name for account (unique, immutable)
+          required: true
+          in: body
+        - name: description
+          description: Description of account
+          required: false
+          in: body
+        - name: contact
+          description: Contact information
+          required: false
+          in: body
+        - name: mail
+          description: Email address for contact
+          required: false
+          in: body
+      responses:
+        '201':
+          description: Created
+          schema:
+            $ref: #/definitions/Account
+        '400':
+          description: Unprocessable Entry, the Account data provided has issues.
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error. There was a problem creating the account
+          schema:
+            $ref: #/definitions/Error
+  '/pdnsadmin/accounts/{account_name}':
+    parameters:
+      - name: account_name
+        type: string
+        in: path
+        required: true
+        description: The name of the account to retrieve
+    get:
+      security:
+        - basicAuth: []
+      summary: Get a specific Account on the server
+      operationId: api_list_accounts
+      tags:
+        - user
+      responses:
+        '200':
+          description: Retrieve a specific account
+          schema:
+            $ref: #/definitions/Account
+        '404':
+          description: Not found. The Account with the specified name does not exist
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error, account could not be retrieved. Contains error message
+          schema:
+            $ref: #/definitions/Error
+  '/pdnsadmin/accounts/{account_id}':
+    parameters:
+      - name: account_id
+        type: integer
+        in: path
+        required: true
+        description: The id of the account to modify or delete
+    put:
+      security:
+        - basicAuth: []
+      summary: Modify a specific Account on the server with supplied parameters
+      operationId: api_update_account
+      tags:
+        - user
+      parameters:
+        - name: name
+          description: Name for account (unique, immutable)
+          required: true
+          in: body
+        - name: description
+          description: Description of account
+          required: false
+          in: body
+        - name: contact
+          description: Contact information
+          required: false
+          in: body
+        - name: mail
+          description: Email address for contact
+          required: false
+          in: body
+      responses:
+        '204':
+          description: OK. Account is modified (empty response body)
+        '404':
+          description: Not found. The Account with the specified account_id does not exist
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error. Contains error message
+          schema:
+            $ref: #/definitions/Error
+    delete:
+      security:
+        - basicAuth: []
+      summary: Delete a specific Account
+      operationId: api_delete_account
+      tags:
+        - user
+      responses:
+        '204':
+          description: OK. Account is deleted (empty response body)
+        '404':
+          description: Not found. The Account with the specified account_id does not exist
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error. Contains error message
+          schema:
+            $ref: #/definitions/Error
+  '/pdnsadmin/accounts/users/{account_id}':
+    parameters:
+      - name: account_id
+        type: integer
+        in: path
+        required: true
+        description: The id of the account to list users linked to account
+    get:
+      security:
+        - basicAuth: []
+      summary: List users linked to a specific account
+      operationId: api_list_account_users
+      tags:
+        - account
+        - user
+      responses:
+        '200':
+          description: List of User objects
+          schema:
+            type: array
+            items:
+              $ref: #/definitions/User
+        '404':
+          description: Not found. The Account with the specified account_id does not exist
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error, accounts could not be retrieved. Contains error message
+          schema:
+            $ref: #/definitions/Error
+  '/pdnsadmin/accounts/users/{account_id}/{user_id}':
+    parameters:
+      - name: account_id
+        type: integer
+        in: path
+        required: true
+        description: The id of the account to link/unlink users to account
+      - name: user_id
+        type: integer
+        in: path
+        required: true
+        description: The id of the user to (un)link to/from account
+    put:
+      security:
+        - basicAuth: []
+      summary: Link user to account
+      operationId: api_add_account_user
+      tags:
+        - account
+        - user
+      responses:
+        '204':
+          description: OK. User is linked (empty response body)
+        '404':
+          description: Not found. The Account or User with the specified id does not exist
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error. Contains error message
+          schema:
+            $ref: #/definitions/Error
+    delete:
+      security:
+        - basicAuth: []
+      summary: Unlink user from account
+      operationId: api_remove_account_user
+      tags:
+        - account
+        - user
+      responses:
+        '204':
+          description: OK. User is unlinked (empty response body)
+        '404':
+          description: Not found. The Account or User with the specified id does not exist or user was not linked to account
+          schema:
+            $ref: #/definitions/Error
+        '500':
+          description: Internal Server Error. Contains error message
+          schema:
+            $ref: #/definitions/Error
+
+
 definitions:
   Server:
     title: Server
@@ -1221,6 +1639,72 @@ definitions:
       description:
         type: string
         description: 'Some user defined description'
+
+  User:
+    title: User
+    description: User that can access the gui/api
+    properties:
+      id:
+        type: integer
+        description: The ID for this user (unique)
+        readOnly: true
+      username:
+        type: string
+        description: The username for this user (unique, immutable)
+        readOnly: false
+      password:
+        type: string
+        description: The hashed password for this user
+        readOnly: false
+      firstname:
+        type: string
+        description: The firstname of this user
+        readOnly: false
+      lastname:
+        type: string
+        description: The lastname of this user
+        readOnly: false
+      email:
+        type: string
+        description: Email addres for this user
+        readOnly: false
+      otp_secret:
+        type: string
+        description: OTP secret
+        readOnly: false
+      confirmed:
+        type: boolean
+        description: The confirmed status
+        readOnly: false
+      role_id:
+        type: integer
+        description: The ID of the role
+        readOnly: false
+
+  Account:
+    title: Account
+    description: Account that 'owns' zones
+    properties:
+      id:
+        type: integer
+        description: The ID for this account (unique)
+        readOnly: true
+      name:
+        type: string
+        description: The name for this account (unique, immutable)
+        readOnly: false
+      description:
+        type: string
+        description: The description for this account
+        readOnly: false
+      contact:
+        type: string
+        description: The contact details for this account
+        readOnly: false
+      mail:
+        type: string
+        description: The email address of the contact for this account
+        readOnly: false
 
   ConfigSetting:
     title: ConfigSetting

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -39,6 +39,16 @@ def load_data(setting_name, *args, **kwargs):
 
 
 @pytest.fixture
+def test_admin_user():
+    return app.config.get('TEST_ADMIN_USER')
+
+
+@pytest.fixture
+def test_user():
+    return app.config.get('TEST_USER')
+
+
+@pytest.fixture
 def basic_auth_admin_headers():
     test_admin_user = app.config.get('TEST_ADMIN_USER')
     test_admin_pass = app.config.get('TEST_ADMIN_PASSWORD')
@@ -284,3 +294,29 @@ def create_apikey_headers(passw):
     user_pass_base64 = b64encode(passw.encode('utf-8'))
     headers = {"X-API-KEY": "{0}".format(user_pass_base64.decode('utf-8'))}
     return headers
+
+
+@pytest.fixture
+def account_data():
+    data = {
+        "name": "test1",
+        "description": "test1 account",
+        "contact": "test1 contact",
+        "mail": "test1@example.com",
+    }
+    return data
+
+
+@pytest.fixture
+def user1_data():
+    data = {
+        "username": "testuser1",
+        "plain_text_password": "ChangeMePlease",
+        "firstname": "firstname1",
+        "lastname": "lastname1",
+        "email": "testuser1@example.com",
+        "otp_secret": "",
+        "confirmed": False,
+        "role_name": "User",
+    }
+    return data

--- a/tests/integration/api/management/__init__.py
+++ b/tests/integration/api/management/__init__.py
@@ -1,0 +1,54 @@
+
+
+class IntegrationApiManagement(object):
+
+    def get_account(self, account_name, status_code=200):
+        res = self.client.get(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_name),
+            headers=self.basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        if isinstance(status_code, (tuple, list)):
+            assert res.status_code in status_code
+        elif status_code:
+            assert res.status_code == status_code
+        if res.status_code == 200:
+            data = res.get_json(force=True)
+            assert len(data) == 1
+            return data[0]
+        return None
+
+    def check_account(self, cmpdata, data=None):
+        data = self.get_account(cmpdata["name"])
+        for key, value in cmpdata.items():
+            assert data[key] == value
+        return data
+
+    def get_user(self, username, status_code=200):
+        res = self.client.get(
+            "/api/v1/pdnsadmin/users/{}".format(username),
+            headers=self.basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        if isinstance(status_code, (tuple, list)):
+            assert res.status_code in status_code
+        elif status_code:
+            assert res.status_code == status_code
+        assert res.status_code == status_code
+        if status_code == 200:
+            data = res.get_json(force=True)
+            assert len(data) == 1
+            return data[0]
+        return None
+
+    def check_user(self, cmpdata, data=None):
+        if data is None:
+            data = self.get_user(cmpdata["username"])
+        for key, value in data.items():
+            if key in ('username', 'firstname', 'lastname', 'email'):
+                assert cmpdata[key] == value
+            elif key == 'role':
+                assert data[key]['name'] == cmpdata['role_name']
+            else:
+                assert key in ("id",)
+        return data

--- a/tests/integration/api/management/test_admin_user.py
+++ b/tests/integration/api/management/test_admin_user.py
@@ -1,0 +1,367 @@
+
+import json
+from tests.fixtures import (    # noqa: F401
+    client, initial_data, basic_auth_admin_headers,
+    test_admin_user, test_user, account_data, user1_data,
+)
+from . import IntegrationApiManagement
+
+
+class TestIntegrationApiManagementAdminUser(IntegrationApiManagement):
+
+    def test_accounts_empty_get(
+            self, client, initial_data,                         # noqa: F811
+            basic_auth_admin_headers):                          # noqa: F811
+        res = client.get("/api/v1/pdnsadmin/accounts",
+                         headers=basic_auth_admin_headers)
+        data = res.get_json(force=True)
+        assert res.status_code == 200
+        assert data == []
+
+    def test_users_empty_get(
+            self, client, initial_data,                         # noqa: F811
+            test_admin_user, test_user,                         # noqa: F811
+            basic_auth_admin_headers):                          # noqa: F811
+        res = client.get("/api/v1/pdnsadmin/users",
+                         headers=basic_auth_admin_headers)
+        data = res.get_json(force=True)
+        assert res.status_code == 200
+        # Initally contains 2 records
+        assert len(data) == 2
+        for user in data:
+            assert user["username"] in (test_admin_user, test_user)
+
+    def test_accounts(
+            self, client, initial_data,                         # noqa: F811
+            account_data,                                       # noqa: F811
+            basic_auth_admin_headers):                          # noqa: F811
+        account_name = account_data["name"]
+        self.client = client
+        self.basic_auth_admin_headers = basic_auth_admin_headers
+
+        # Create account
+        res = client.post(
+            "/api/v1/pdnsadmin/accounts",
+            headers=basic_auth_admin_headers,
+            data=json.dumps(account_data),
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 201
+
+        # Check account
+        data = self.check_account(account_data)
+        account_id = data["id"]
+
+        updated = account_data.copy()
+        # Update and check values
+        for upd_key in ["description", "contact", "mail"]:
+            upd_value = "upd-{}".format(account_data[upd_key])
+
+            # Update
+            data = {"name": account_name, upd_key: upd_value}
+            res = client.put(
+                "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+                data=json.dumps(data),
+                headers=basic_auth_admin_headers,
+                content_type="application/json",
+            )
+            assert res.status_code == 204
+            updated[upd_key] = upd_value
+
+            # Check
+            data = self.check_account(updated)
+
+        # Update to defaults
+        res = client.put(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Check account
+        res = client.get(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_name),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 200
+        assert len(data) == 1
+        data = data[0]
+        account_id = data["id"]
+        for key, value in account_data.items():
+            assert data[key] == value
+
+        # Cleanup (delete account)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Get non-existing account (should fail)
+        data = self.get_account(account_name, status_code=404)
+
+        # Update non-existing account (should fail)
+        res = client.put(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+        # Delete non-existing account (should fail)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+    def test_users(
+            self, client, initial_data,                         # noqa: F811
+            user1_data,                                         # noqa: F811
+            basic_auth_admin_headers):                          # noqa: F811
+        user1name = user1_data["username"]
+        self.client = client
+        self.basic_auth_admin_headers = basic_auth_admin_headers
+
+        # Create user (user1)
+        res = client.post(
+            "/api/v1/pdnsadmin/users",
+            headers=basic_auth_admin_headers,
+            data=json.dumps(user1_data),
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 201
+        assert len(data) == 1
+
+        # Check user
+        user1 = self.check_user(user1_data, data[0])
+        user1_id = user1["id"]
+
+        updated = user1_data.copy()
+        # Update and check values
+        for upd_key in ["firstname", "lastname", "email"]:
+            upd_value = "upd-{}".format(user1_data[upd_key])
+
+            # Update
+            data = {"username": user1name, upd_key: upd_value}
+            res = client.put(
+                "/api/v1/pdnsadmin/users/{}".format(user1_id),
+                data=json.dumps(data),
+                headers=basic_auth_admin_headers,
+                content_type="application/json",
+            )
+            assert res.status_code == 204
+            updated[upd_key] = upd_value
+
+            # Check
+            data = self.check_user(updated)
+
+        # Update to defaults
+        res = client.put(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Check user
+        self.check_user(user1_data)
+
+        # Cleanup (delete user)
+        res = client.delete(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Get non-existing user (should fail)
+        data = self.get_user(user1name, status_code=404)
+
+        # Update non-existing user (should fail)
+        res = client.put(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+        # Delete non-existing user (should fail)
+        res = client.delete(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+    def test_account_users(
+            self, client, initial_data,                         # noqa: F811
+            test_user, account_data, user1_data,                # noqa: F811
+            basic_auth_admin_headers):                          # noqa: F811
+        self.client = client
+        self.basic_auth_admin_headers = basic_auth_admin_headers
+        test_user_id = self.get_user(test_user)["id"]
+
+        # Create account
+        res = client.post(
+            "/api/v1/pdnsadmin/accounts",
+            headers=basic_auth_admin_headers,
+            data=json.dumps(account_data),
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 201
+
+        # Check account
+        data = self.check_account(account_data)
+        account_id = data["id"]
+
+        # Create user1
+        res = client.post(
+            "/api/v1/pdnsadmin/users",
+            headers=basic_auth_admin_headers,
+            data=json.dumps(user1_data),
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 201
+        assert len(data) == 1
+
+        # Check user
+        user1 = self.check_user(user1_data, data[0])
+        user1_id = user1["id"]
+
+        # Assert test account has no users
+        res = client.get(
+            "/api/v1/pdnsadmin/accounts/users/{}".format(account_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 200
+        assert data == []
+
+        # Assert unlinking an unlinked account fails
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+        # Link user to account
+        res = client.put(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Check user is linked to account
+        res = client.get(
+            "/api/v1/pdnsadmin/accounts/users/{}".format(account_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 200
+        assert len(data) == 1
+        self.check_user(user1_data, data[0])
+
+        # Unlink user from account
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Check user is unlinked from account
+        res = client.get(
+            "/api/v1/pdnsadmin/accounts/users/{}".format(account_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 200
+        assert data == []
+
+        # Unlink unlinked user from account (should fail)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+        # Cleanup (delete user)
+        res = client.delete(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Link non-existing user to account (should fail)
+        res = client.put(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+        # Unlink non-exiting user from account (should fail)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+        # Cleanup (delete account)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # List users in non-existing account (should fail)
+        res = client.get(
+            "/api/v1/pdnsadmin/accounts/users/{}".format(account_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404
+
+        # Link existing user to non-existing account (should fail)
+        res = client.put(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, test_user_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 404

--- a/tests/integration/api/management/test_user.py
+++ b/tests/integration/api/management/test_user.py
@@ -1,0 +1,252 @@
+
+import json
+
+from tests.fixtures import (    # noqa: F401
+    client, initial_data, basic_auth_admin_headers, basic_auth_user_headers,
+    test_admin_user, test_user, account_data, user1_data,
+)
+from . import IntegrationApiManagement
+
+
+class TestIntegrationApiManagementUser(IntegrationApiManagement):
+
+    def test_accounts_empty_get(
+            self, client, initial_data,                         # noqa: F811
+            basic_auth_user_headers):                           # noqa: F811
+        res = client.get("/api/v1/pdnsadmin/accounts",
+                         headers=basic_auth_user_headers)
+        assert res.status_code == 401
+
+    def test_users_empty_get(
+            self, client, initial_data,                         # noqa: F811
+            test_admin_user, test_user,                         # noqa: F811
+            basic_auth_user_headers):                           # noqa: F811
+        res = client.get("/api/v1/pdnsadmin/users",
+                         headers=basic_auth_user_headers)
+        assert res.status_code == 401
+
+    def test_self_get(
+            self, initial_data, client, test_user,              # noqa: F811
+            basic_auth_user_headers):                           # noqa: F811
+        self.user = None
+        res = client.get("/api/v1/pdnsadmin/users/{}".format(test_user),
+                         headers=basic_auth_user_headers)
+        data = res.get_json(force=True)
+        assert res.status_code == 200
+        assert len(data) == 1, data
+        self.user = data
+
+    def test_accounts(
+            self, client, initial_data,                          # noqa: F811
+            account_data,                                        # noqa: F811
+            basic_auth_admin_headers, basic_auth_user_headers):  # noqa: F811
+        self.client = client
+        self.basic_auth_admin_headers = basic_auth_admin_headers
+
+        # Create account (should fail)
+        res = client.post(
+            "/api/v1/pdnsadmin/accounts",
+            headers=basic_auth_user_headers,
+            data=json.dumps(account_data),
+            content_type="application/json",
+        )
+        assert res.status_code == 401
+
+        # Create account (as admin)
+        res = client.post(
+            "/api/v1/pdnsadmin/accounts",
+            headers=basic_auth_admin_headers,
+            data=json.dumps(account_data),
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 201
+
+        # Check account
+        data = self.check_account(account_data)
+        account_id = data["id"]
+
+        # Update to defaults (should fail)
+        res = client.put(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_user_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 401
+
+        # Delete account (should fail)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_user_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 401
+
+        # Cleanup (delete account as admin)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+    def test_users(
+            self, client, initial_data,                          # noqa: F811
+            user1_data,                                          # noqa: F811
+            basic_auth_admin_headers, basic_auth_user_headers):  # noqa: F811
+        self.client = client
+        self.basic_auth_admin_headers = basic_auth_admin_headers
+
+        # Create user1 (should fail)
+        res = client.post(
+            "/api/v1/pdnsadmin/users",
+            headers=basic_auth_user_headers,
+            data=json.dumps(user1_data),
+            content_type="application/json",
+        )
+        assert res.status_code == 401
+
+        # Create user1 (as admin)
+        res = client.post(
+            "/api/v1/pdnsadmin/users",
+            headers=basic_auth_admin_headers,
+            data=json.dumps(user1_data),
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 201
+        assert len(data) == 1
+
+        # Check user
+        user1 = self.check_user(user1_data, data[0])
+        user1_id = user1["id"]
+
+        # Update to defaults (should fail)
+        res = client.put(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_user_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 401
+
+        # Delete user (should fail)
+        res = client.delete(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_user_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 401
+
+        # Cleanup (delete user as admin)
+        res = client.delete(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+    def test_account_users(
+            self, client, initial_data,                          # noqa: F811
+            account_data, user1_data,                            # noqa: F811
+            basic_auth_admin_headers, basic_auth_user_headers):  # noqa: F811
+        self.client = client
+        self.basic_auth_admin_headers = basic_auth_admin_headers
+
+        # Create account
+        res = client.post(
+            "/api/v1/pdnsadmin/accounts",
+            headers=basic_auth_admin_headers,
+            data=json.dumps(account_data),
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 201
+
+        # Check account
+        data = self.check_account(account_data)
+        account_id = data["id"]
+
+        # Create user1
+        res = client.post(
+            "/api/v1/pdnsadmin/users",
+            headers=basic_auth_admin_headers,
+            data=json.dumps(user1_data),
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 201
+        assert len(data) == 1
+
+        # Check user
+        user1 = self.check_user(user1_data, data[0])
+        user1_id = user1["id"]
+
+        # Assert test account has no users
+        res = client.get(
+            "/api/v1/pdnsadmin/accounts/users/{}".format(account_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        data = res.get_json(force=True)
+        assert res.status_code == 200
+        assert data == []
+
+        # Link user to account (as user, should fail)
+        res = client.put(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_user_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 401
+
+        # Link user to account (as admin)
+        res = client.put(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Unlink user from account (as user, should fail)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_user_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 401
+
+        # Unlink user from account (as admin)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/users/{}/{}".format(
+                account_id, user1_id),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Cleanup (delete user)
+        res = client.delete(
+            "/api/v1/pdnsadmin/users/{}".format(user1_id),
+            data=json.dumps(user1_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204
+
+        # Cleanup (delete account)
+        res = client.delete(
+            "/api/v1/pdnsadmin/accounts/{}".format(account_id),
+            data=json.dumps(account_data),
+            headers=basic_auth_admin_headers,
+            content_type="application/json",
+        )
+        assert res.status_code == 204


### PR DESCRIPTION
Comment(s) on multiple records for the same name/type throw an error (500 in the webinterface).

In the logging:
```
Traceback (most recent call last):
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 2446, in wsgi_app
     response = self.full_dispatch_request()
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 1951, in full_dispatch_request
     rv = self.handle_user_exception(e)
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 1820, in handle_user_exception
     reraise(exc_type, exc_value, tb)
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/_compat.py", line 39, in reraise
     raise value
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 1949, in full_dispatch_request
     rv = self.dispatch_request()
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 1935, in dispatch_request
     return self.view_functions[rule.endpoint](**req.view_args)
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask_login/utils.py", line 261, in decorated_view
     return func(*args, **kwargs)
   File "/opt/pdnsadm/powerdns-admin/powerdnsadmin/decorators.py", line 60, in decorated_function
     return f(*args, **kwargs)
   File "/opt/pdnsadm/powerdns-admin/powerdnsadmin/routes/domain.py", line 109, in domain
     if r['comments'] else '',
 IndexError: list index out of range 
```

In the workaround the 500 is prevented and comments are shown on best-effort:
- If no comment(s) -> ''
- If comment for index (whatever relation there may be), the comment for that index
- If comment but not for this index -> comment for index=0