### PR TITLE
Workaround for comment(s) on multiple records for same name+type

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -99,14 +99,19 @@ def domain(domain_name):
                 # PDA jinja2 template can understand.
                 index = 0
                 for record in r['records']:
+                    try:
+                        comment = ''
+                        comment = r['comments'][0]['content']
+                        comment = r['comments'][index]['content']
+                    except (KeyError, IndexError):
+                        pass
                     record_entry = RecordEntry(
                         name=r_name,
                         type=r['type'],
                         status='Disabled' if record['disabled'] else 'Active',
                         ttl=r['ttl'],
                         data=record['content'],
-                        comment=r['comments'][index]['content']
-                        if r['comments'] else '',
+                        comment=comment,
                         is_allowed_edit=True)
                     index += 1
                     records.append(record_entry)


### PR DESCRIPTION
Comment(s) on multiple records for the same name/type throw an error (500 in the webinterface).

In the logging:
```
Traceback (most recent call last):
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 2446, in wsgi_app
     response = self.full_dispatch_request()
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 1951, in full_dispatch_request
     rv = self.handle_user_exception(e)
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 1820, in handle_user_exception
     reraise(exc_type, exc_value, tb)
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/_compat.py", line 39, in reraise
     raise value
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 1949, in full_dispatch_request
     rv = self.dispatch_request()
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask/app.py", line 1935, in dispatch_request
     return self.view_functions[rule.endpoint](**req.view_args)
   File "/opt/pdnsadm/py-pdns-adm/lib/python3.6/site-packages/flask_login/utils.py", line 261, in decorated_view
     return func(*args, **kwargs)
   File "/opt/pdnsadm/powerdns-admin/powerdnsadmin/decorators.py", line 60, in decorated_function
     return f(*args, **kwargs)
   File "/opt/pdnsadm/powerdns-admin/powerdnsadmin/routes/domain.py", line 109, in domain
     if r['comments'] else '',
 IndexError: list index out of range
```

In the workaround the 500 is prevented and comments are shown on best-effort:
- If no comment(s) -> ''
- If comment for index (whatever relation there may be), the comment for that index
- If comment but not for this index -> comment for index=0