### PR TITLE
Add docker secrets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ There are several ways to run PowerDNS-Admin. Following is a simple way to start
 Step 1: Update the configuration
 
 Edit the `docker-compose.yml` file to update the database connection string in `SQLALCHEMY_DATABASE_URI`. Other environment variables are mentioned in the [legal_envvars](https://github.com/ngoduykhanh/PowerDNS-Admin/blob/master/configs/docker_config.py#L5-L37).
+To use docker secret feature it is possible to append `_FILE` to the environment variables and point to a file with the value stored in it.
 
 Step 2: Start docker container
 

--- a/configs/docker_config.py
+++ b/configs/docker_config.py
@@ -64,8 +64,21 @@ legal_envvars_bool = (
 import os
 import sys
 for v in legal_envvars:
-    if v in os.environ:
+
+    ret = None
+    # _FILE suffix will allow to read value from file, usefull for Docker's
+    # secrets feature
+    if v + '_FILE' in os.environ:
+        if v in os.environ:
+            raise AttributeError("Both {} and {} are set but are exclusive." .format(v, v + '_FILE'))
+        with open(os.environ[v + '_FILE']) as f:
+            ret = f.read()
+        f.close()
+
+    elif v in os.environ:
         ret = os.environ[v]
+
+    if ret is not None:
         if v in legal_envvars_bool:
             ret = bool(ret)
         if v in legal_envvars_int:


### PR DESCRIPTION
Can you add this request, it enables support for docker secrets. This gives a more secure option of storing credentials and pass them to containers.