### PR TITLE
Support only having one auth method enabled 

### DIFF
--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -602,6 +602,20 @@ def setting_records():
         Setting().set('reverse_records_allow_edit', str(rr))
         return redirect(url_for('admin.setting_records'))
 
+def has_an_auth_method(local_db_enabled = None,ldap_enabled = None,google_oauth_enabled = None,github_oauth_enabled = None,oidc_oauth_enabled = None,azure_oauth_enabled = None):
+    if local_db_enabled is None:
+        local_db_enabled = Setting().get('local_db_enabled')
+    if ldap_enabled is None:
+        ldap_enabled = Setting().get('ldap_enabled')
+    if google_oauth_enabled is None:
+        google_oauth_enabled = Setting().get('google_oauth_enabled')
+    if github_oauth_enabled is None:
+        github_oauth_enabled = Setting().get('github_oauth_enabled')
+    if oidc_oauth_enabled is None:
+        oidc_oauth_enabled = Setting().get('oidc_oauth_enabled')
+    if azure_oauth_enabled is None:
+        azure_oauth_enabled = Setting().get('azure_oauth_enabled')
+    return local_db_enabled or ldap_enabled or google_oauth_enabled or github_oauth_enabled or oidc_oauth_enabled or azure_oauth_enabled
 
 @admin_bp.route('/setting/authentication', methods=['GET', 'POST'])
 @login_required
@@ -619,12 +633,12 @@ def setting_authentication():
             signup_enabled = True if request.form.get(
                 'signup_enabled', ) else False
 
-            if not local_db_enabled and not Setting().get('ldap_enabled'):
+            if not has_an_auth_method(local_db_enabled=local_db_enabled):
                 result = {
                     'status':
                     False,
                     'msg':
-                    'Local DB and LDAP Authentication can not be disabled at the same time.'
+                    'Must have at least one authentication method enabled.'
                 }
             else:
                 Setting().set('local_db_enabled', local_db_enabled)
@@ -633,12 +647,12 @@ def setting_authentication():
         elif conf_type == 'ldap':
             ldap_enabled = True if request.form.get('ldap_enabled') else False
 
-            if not ldap_enabled and not Setting().get('local_db_enabled'):
+            if not has_an_auth_method(ldap_enabled=ldap_enabled):
                 result = {
                     'status':
-                    False,
+                        False,
                     'msg':
-                    'Local DB and LDAP Authentication can not be disabled at the same time.'
+                        'Must have at least one authentication method enabled.'
                 }
             else:
                 Setting().set('ldap_enabled', ldap_enabled)
@@ -669,88 +683,128 @@ def setting_authentication():
                 Setting().set('ldap_domain', request.form.get('ldap_domain'))
                 result = {'status': True, 'msg': 'Saved successfully'}
         elif conf_type == 'google':
-            Setting().set(
-                'google_oauth_enabled',
-                True if request.form.get('google_oauth_enabled') else False)
-            Setting().set('google_oauth_client_id',
-                          request.form.get('google_oauth_client_id'))
-            Setting().set('google_oauth_client_secret',
-                          request.form.get('google_oauth_client_secret'))
-            Setting().set('google_token_url',
-                          request.form.get('google_token_url'))
-            Setting().set('google_oauth_scope',
-                          request.form.get('google_oauth_scope'))
-            Setting().set('google_authorize_url',
-                          request.form.get('google_authorize_url'))
-            Setting().set('google_base_url',
-                          request.form.get('google_base_url'))
-            result = {
-                'status': True,
-                'msg': 'Saved successfully. Please reload PDA to take effect.'
-            }
+            google_oauth_enabled = True if request.form.get(
+                'google_oauth_enabled') else False
+            if not has_an_auth_method(google_oauth_enabled=google_oauth_enabled):
+                result = {
+                    'status':
+                        False,
+                    'msg':
+                        'Must have at least one authentication method enabled.'
+                }
+            else:
+                Setting().set(
+                    'google_oauth_enabled',
+                    google_oauth_enabled)
+                Setting().set('google_oauth_client_id',
+                              request.form.get('google_oauth_client_id'))
+                Setting().set('google_oauth_client_secret',
+                              request.form.get('google_oauth_client_secret'))
+                Setting().set('google_token_url',
+                              request.form.get('google_token_url'))
+                Setting().set('google_oauth_scope',
+                              request.form.get('google_oauth_scope'))
+                Setting().set('google_authorize_url',
+                              request.form.get('google_authorize_url'))
+                Setting().set('google_base_url',
+                              request.form.get('google_base_url'))
+                result = {
+                    'status': True,
+                    'msg': 'Saved successfully. Please reload PDA to take effect.'
+                }
         elif conf_type == 'github':
-            Setting().set(
-                'github_oauth_enabled',
-                True if request.form.get('github_oauth_enabled') else False)
-            Setting().set('github_oauth_key',
-                          request.form.get('github_oauth_key'))
-            Setting().set('github_oauth_secret',
-                          request.form.get('github_oauth_secret'))
-            Setting().set('github_oauth_scope',
-                          request.form.get('github_oauth_scope'))
-            Setting().set('github_oauth_api_url',
-                          request.form.get('github_oauth_api_url'))
-            Setting().set('github_oauth_token_url',
-                          request.form.get('github_oauth_token_url'))
-            Setting().set('github_oauth_authorize_url',
-                          request.form.get('github_oauth_authorize_url'))
-            result = {
-                'status': True,
-                'msg': 'Saved successfully. Please reload PDA to take effect.'
-            }
+            github_oauth_enabled = True if request.form.get(
+                'github_oauth_enabled') else False
+            if not has_an_auth_method(github_oauth_enabled=github_oauth_enabled):
+                result = {
+                    'status':
+                        False,
+                    'msg':
+                        'Must have at least one authentication method enabled.'
+                }
+            else:
+                Setting().set(
+                    'github_oauth_enabled',
+                    github_oauth_enabled)
+                Setting().set('github_oauth_key',
+                              request.form.get('github_oauth_key'))
+                Setting().set('github_oauth_secret',
+                              request.form.get('github_oauth_secret'))
+                Setting().set('github_oauth_scope',
+                              request.form.get('github_oauth_scope'))
+                Setting().set('github_oauth_api_url',
+                              request.form.get('github_oauth_api_url'))
+                Setting().set('github_oauth_token_url',
+                              request.form.get('github_oauth_token_url'))
+                Setting().set('github_oauth_authorize_url',
+                              request.form.get('github_oauth_authorize_url'))
+                result = {
+                    'status': True,
+                    'msg': 'Saved successfully. Please reload PDA to take effect.'
+                }
         elif conf_type == 'azure':
-            Setting().set(
-                'azure_oauth_enabled',
-                True if request.form.get('azure_oauth_enabled') else False)
-            Setting().set('azure_oauth_key',
-                          request.form.get('azure_oauth_key'))
-            Setting().set('azure_oauth_secret',
-                          request.form.get('azure_oauth_secret'))
-            Setting().set('azure_oauth_scope',
-                          request.form.get('azure_oauth_scope'))
-            Setting().set('azure_oauth_api_url',
-                          request.form.get('azure_oauth_api_url'))
-            Setting().set('azure_oauth_token_url',
-                          request.form.get('azure_oauth_token_url'))
-            Setting().set('azure_oauth_authorize_url',
-                          request.form.get('azure_oauth_authorize_url'))
-            Setting().set('azure_sg_enabled', True if request.form.get('azure_sg_enabled')=='ON' else False)
-            Setting().set('azure_admin_group', request.form.get('azure_admin_group'))
-            Setting().set('azure_operator_group', request.form.get('azure_operator_group'))
-            Setting().set('azure_user_group', request.form.get('azure_user_group'))
-            result = {
-                'status': True,
-                'msg': 'Saved successfully. Please reload PDA to take effect.'
-            }
+            azure_oauth_enabled = True if request.form.get(
+                'azure_oauth_enabled') else False
+            if not has_an_auth_method(azure_oauth_enabled=azure_oauth_enabled):
+                result = {
+                    'status':
+                        False,
+                    'msg':
+                        'Must have at least one authentication method enabled.'
+                }
+            else:
+                Setting().set(
+                    'azure_oauth_enabled',
+                    azure_oauth_enabled)
+                Setting().set('azure_oauth_key',
+                              request.form.get('azure_oauth_key'))
+                Setting().set('azure_oauth_secret',
+                              request.form.get('azure_oauth_secret'))
+                Setting().set('azure_oauth_scope',
+                              request.form.get('azure_oauth_scope'))
+                Setting().set('azure_oauth_api_url',
+                              request.form.get('azure_oauth_api_url'))
+                Setting().set('azure_oauth_token_url',
+                              request.form.get('azure_oauth_token_url'))
+                Setting().set('azure_oauth_authorize_url',
+                              request.form.get('azure_oauth_authorize_url'))
+                Setting().set('azure_sg_enabled', True if request.form.get('azure_sg_enabled')=='ON' else False)
+                Setting().set('azure_admin_group', request.form.get('azure_admin_group'))
+                Setting().set('azure_operator_group', request.form.get('azure_operator_group'))
+                Setting().set('azure_user_group', request.form.get('azure_user_group'))
+                result = {
+                    'status': True,
+                    'msg': 'Saved successfully. Please reload PDA to take effect.'
+                }
         elif conf_type == 'oidc':
-            Setting().set(
-                'oidc_oauth_enabled',
-                True if request.form.get('oidc_oauth_enabled') else False)
-            Setting().set('oidc_oauth_key', request.form.get('oidc_oauth_key'))
-            Setting().set('oidc_oauth_secret',
-                          request.form.get('oidc_oauth_secret'))
-            Setting().set('oidc_oauth_scope',
-                          request.form.get('oidc_oauth_scope'))
-            Setting().set('oidc_oauth_api_url',
-                          request.form.get('oidc_oauth_api_url'))
-            Setting().set('oidc_oauth_token_url',
-                          request.form.get('oidc_oauth_token_url'))
-            Setting().set('oidc_oauth_authorize_url',
-                          request.form.get('oidc_oauth_authorize_url'))
-            result = {
-                'status': True,
-                'msg': 'Saved successfully. Please reload PDA to take effect.'
-            }
+            oidc_oauth_enabled = True if request.form.get(
+                'oidc_oauth_enabled') else False
+            if not has_an_auth_method(oidc_oauth_enabled=oidc_oauth_enabled):
+                result = {
+                    'status':
+                        False,
+                    'msg':
+                        'Must have at least one authentication method enabled.'
+                }
+            else:
+                Setting().set(
+                    'oidc_oauth_enabled',
+                    True if request.form.get('oidc_oauth_enabled') else False)
+                Setting().set('oidc_oauth_key', request.form.get('oidc_oauth_key'))
+                Setting().set('oidc_oauth_secret',
+                              request.form.get('oidc_oauth_secret'))
+                Setting().set('oidc_oauth_scope',
+                              request.form.get('oidc_oauth_scope'))
+                Setting().set('oidc_oauth_api_url',
+                              request.form.get('oidc_oauth_api_url'))
+                Setting().set('oidc_oauth_token_url',
+                              request.form.get('oidc_oauth_token_url'))
+                Setting().set('oidc_oauth_authorize_url',
+                              request.form.get('oidc_oauth_authorize_url'))
+                result = {
+                    'status': True,
+                    'msg': 'Saved successfully. Please reload PDA to take effect.'
+                }
         else:
             return abort(400)
 

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -321,6 +321,12 @@ def login():
             'authentication_type'] = 'LDAP' if auth_method != 'LOCAL' else 'LOCAL'
         remember_me = True if 'remember' in request.form else False
 
+        if auth_method == 'LOCAL' and not Setting().get('local_db_enabled'):
+            return render_template(
+                'login.html',
+                saml_enabled=SAML_ENABLED,
+                error='Local authentication is disabled')
+
         user = User(username=username,
                     password=password,
                     plain_text_password=password)

--- a/powerdnsadmin/templates/login.html
+++ b/powerdnsadmin/templates/login.html
@@ -32,6 +32,7 @@
         {{ error }}
       </div>
       {% endif %}
+      {% if SETTING.get('ldap_enabled') or SETTING.get('local_db_enabled') %}
       <form action="" method="post" data-toggle="validator">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
         <div class="form-group">
@@ -87,9 +88,12 @@
           <!-- /.col -->
         </div>
       </form>
+      {% endif %}
       {% if SETTING.get('google_oauth_enabled') or SETTING.get('github_oauth_enabled') or SETTING.get('oidc_oauth_enabled') or SETTING.get('azure_oauth_enabled') %}
       <div class="social-auth-links text-center">
+        {% if SETTING.get('ldap_enabled') or SETTING.get('local_db_enabled') %}
         <p>- OR -</p>
+        {% endif %}
         {% if SETTING.get('oidc_oauth_enabled') %}
         <a href="{{ url_for('index.oidc_login') }}" class="btn btn-block btn-social btn-openid btn-flat"><i
             class="fa fa-openid"></i> Sign in using


### PR DESCRIPTION
Currently you can't disable the local db auth if you are using an oauth provider (for example Microsoft Azure).

This adjust the validation to require at least one enabled authentication provider, and ends up being a little noise for a commit