### PR TITLE
Use sqlite by default in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,36 @@ A PowerDNS web interface with advanced features.
 - Edit IPv6 PTRs using IPv6 addresses directly (no more editing of literal addresses!)
 - Limited API for manipulating zones and records
 
-### Running PowerDNS-Admin
-There are several ways to run PowerDNS-Admin. Following is a simple way to start PowerDNS-Admin using Docker
+## Running PowerDNS-Admin
+There are several ways to run PowerDNS-Admin. The easiest way is to use Docker.
+If you are looking to install and run PowerDNS-Admin directly onto your system check out the [Wiki](https://github.com/ngoduykhanh/PowerDNS-Admin/wiki#installation-guides) for ways to do that.
 
-Step 1: Update the configuration
+### Docker
+This are two options to run PowerDNS-Admin using Docker.
+To get started as quickly as possible try option 1. If you want to make modifications to the configuration option 2 may be cleaner.
 
-Edit the `docker-compose.yml` file to update the database connection string in `SQLALCHEMY_DATABASE_URI`. Other environment variables are mentioned in the [legal_envvars](https://github.com/ngoduykhanh/PowerDNS-Admin/blob/master/configs/docker_config.py#L5-L37).
-To use docker secret feature it is possible to append `_FILE` to the environment variables and point to a file with the value stored in it.
+#### Option 1: From Docker Hub
+The easiest is to just run the latest Docker image from Docker Hub:
+```
+$ docker run -d \
+    -v pda-data:/data
+    -p 9191:80 \
+    ngoduykhanh/powerdns-admin:latest
+```
+This creates a volume called `pda-data` to persist the SQLite database with the configuration.
 
-Step 2: Start docker container
+#### Option 2: Using docker-compose
+1. Update the configuration
+   Edit the `docker-compose.yml` file to update the database connection string in `SQLALCHEMY_DATABASE_URI`.
+   Other environment variables are mentioned in the [legal_envvars](https://github.com/ngoduykhanh/PowerDNS-Admin/blob/master/configs/docker_config.py#L5-L46).
+   To use the Docker secrets feature it is possible to append `_FILE` to the environment variables and point to a file with the values stored in it.
 
-```$ docker-compose up```
+2. Start docker container
+   ```
+   $ docker-compose up
+   ```
 
-You can now access PowerDNS-Admin at url http://localhost:9191
+You can then access PowerDNS-Admin by pointing your browser to http://localhost:9191.
 
-**NOTE:** For other methods to run PowerDNS-Admin, please take look at WIKI pages.
-
-### Screenshots
+## Screenshots
 ![dashboard](https://user-images.githubusercontent.com/6447444/44068603-0d2d81f6-9fa5-11e8-83af-14e2ad79e370.png)

--- a/configs/docker_config.py
+++ b/configs/docker_config.py
@@ -1,6 +1,7 @@
 # Defaults for Docker image
 BIND_ADDRESS = '0.0.0.0'
 PORT = 80
+SQLALCHEMY_DATABASE_URI = 'sqlite:////data/powerdns-admin.db'
 
 legal_envvars = (
     'SECRET_KEY',

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,9 @@ ENV FLASK_APP=/app/powerdnsadmin/__init__.py
 
 RUN apk add --no-cache mariadb-connector-c postgresql-client py3-gunicorn py3-psycopg2 xmlsec tzdata && \
     addgroup -S pda && \
-    adduser -S -D -G pda pda
+    adduser -S -D -G pda pda && \
+    mkdir /data && \
+    chown pda:pda /data
 
 COPY --from=builder /usr/bin/flask /usr/bin/
 COPY --from=builder /usr/lib/python3.8/site-packages /usr/lib/python3.8/site-packages/

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,7 +11,9 @@ cat ./powerdnsadmin/default_config.py ./configs/docker_config.py > ./powerdnsadm
 
 GUNICORN_ARGS="-t ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKERS} --bind ${BIND_ADDRESS} --log-level ${GUNICORN_LOGLEVEL}"
 if [ "$1" == gunicorn ]; then
-    flask db upgrade
+    # run as user pda so that if a SQLite database is generated it is writeable
+    # by that user
+    su pda -s /bin/sh -c "flask db upgrade"
     exec "$@" $GUNICORN_ARGS
 
 else


### PR DESCRIPTION
This allows for easy setup with no extra configuration.
Also update docs to reflect the new and easy way to run PowerDNS-Admin.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>