### PR TITLE
Azure oauth fixes

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -218,8 +218,8 @@ def login():
         azure_username = me["userPrincipalName"]
         azure_givenname = me["givenName"]
         azure_familyname = me["surname"]
-        if "email" in me:
-            azure_email = me["email"]
+        if "mail" in me:
+            azure_email = me["mail"]
         else:
             azure_email = ""
         if not azure_email:

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -201,7 +201,7 @@ def login():
         return redirect(url_for('index.index'))
 
     if 'azure_token' in session:
-        azure_info = azure.get('me?$select=displayName,givenName,id,mail,surname,userPrincipalName,preferredName').text
+        azure_info = azure.get('me?$select=displayName,givenName,id,mail,surname,userPrincipalName').text
         current_app.logger.info('Azure login returned: '+azure_info)
         me = json.loads(azure_info)
 


### PR DESCRIPTION
This fixes a bug where if the tenant does not have any licenses (in particular sharepoint online) the get request for preferredName fails due to missing license.

The other fixes a minor name error, where 'email' is used instead of 'mail'