### PR TITLE
Sort rrset members by content before comparison to ensure correct compare

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -99,14 +99,17 @@ def domain(domain_name):
                 # PDA jinja2 template can understand.
                 index = 0
                 for record in r['records']:
+                    if (len(r['comments'])>index):
+                        c=r['comments'][index]['content']
+                    else:
+                        c=''
                     record_entry = RecordEntry(
                         name=r_name,
                         type=r['type'],
                         status='Disabled' if record['disabled'] else 'Active',
                         ttl=r['ttl'],
                         data=record['content'],
-                        comment=r['comments'][index]['content']
-                        if r['comments'] else '',
+                        comment=c,
                         is_allowed_edit=True)
                     index += 1
                     records.append(record_entry)


### PR DESCRIPTION
When comparing submitted with current, the system can sometimes incorrectly things an rrset has changed when in fact it is just the members in a different order.  This can potentially do major damage if a change fails (such as when accidentally adding an A record when a CNAME already exists), as the delete will take place but the re-create fail, resulting in the accidental deletion of an entire rrset unrelated to the change being attempted,

This change adds a sort of the rrset members for both retrieved (get_rrset) and submitted (merge_rrset), sorting the record+comment pair by the record content.  Note that blank comments have to be added if for any reason the comment array is not the same length as the record array for this to work.

Also this change will default comment to blank entry rather than missing entry, to allow sorting to work correctly; this fixes some issues with cases where an rrset has comments on some entries but not others