### PR TITLE
Support authenticating using REMOTE_USER environment variable

### DIFF
--- a/configs/development.py
+++ b/configs/development.py
@@ -130,7 +130,7 @@ SAML_ENABLED = False
 # SAML_CERT_FILE = '/etc/pki/powerdns-admin/cert.crt'
 # SAML_CERT_KEY = '/etc/pki/powerdns-admin/key.pem'
 
-# Cofigures if SAML tokens should be encrypted.
+# Configures if SAML tokens should be encrypted.
 # SAML_SIGN_REQUEST = False
 # #Use SAML standard logout mechanism retreived from idp metadata
 # #If configured false don't care about SAML session on logout.
@@ -141,3 +141,19 @@ SAML_ENABLED = False
 # #SAML_LOGOUT_URL = 'https://google.com'
 
 # #SAML_ASSERTION_ENCRYPTED = True
+
+# Remote authentication settings
+
+# Whether to enable remote user authentication or not
+# Defaults to False
+# REMOTE_USER_ENABLED=True
+
+# If set, users will be redirected to this location on logout
+# Ignore or set to None to avoid redirecting altogether
+# Warning: if REMOTE_USER environment variable is still set after logging out and not cleared by
+# some external module, not defining a custom logout URL might trigger a loop
+# that will just log the user back in right after logging out
+# REMOTE_USER_LOGOUT_URL=https://my.sso.com/cas/logout
+
+# An optional list of remote authentication tied cookies to be removed upon logout
+# REMOTE_USER_COOKIES=['MOD_AUTH_CAS', 'MOD_AUTH_CAS_S']

--- a/configs/docker_config.py
+++ b/configs/docker_config.py
@@ -45,7 +45,9 @@ legal_envvars = (
     'SAML_LOGOUT',
     'SAML_LOGOUT_URL',
     'SAML_ASSERTION_ENCRYPTED',
-    'OFFLINE_MODE'
+    'OFFLINE_MODE',
+    'REMOTE_USER_LOGOUT_URL',
+    'REMOTE_USER_COOKIES'
 )
 
 legal_envvars_int = ('PORT', 'MAIL_PORT', 'SAML_METADATA_CACHE_LIFETIME')
@@ -62,7 +64,8 @@ legal_envvars_bool = (
     'SAML_WANT_MESSAGE_SIGNED',
     'SAML_LOGOUT',
     'SAML_ASSERTION_ENCRYPTED',
-    'OFFLINE_MODE'
+    'OFFLINE_MODE',
+    'REMOTE_USER_ENABLED'
 )
 
 # import everything from environment variables

--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -5,6 +5,7 @@ import requests
 import hashlib
 import ipaddress
 
+from collections.abc import Iterable
 from distutils.version import StrictVersion
 from urllib.parse import urlparse
 from datetime import datetime, timedelta
@@ -211,6 +212,14 @@ def validate_ipaddress(address):
 def pretty_json(data):
     return json.dumps(data, sort_keys=True, indent=4)
 
+
+def ensure_list(l):
+    if not l:
+        l = []
+    elif not isinstance(l, Iterable) or isinstance(l, str):
+        l = [l]
+
+    yield from l
 
 class customBoxes:
     boxes = {

--- a/powerdnsadmin/routes/base.py
+++ b/powerdnsadmin/routes/base.py
@@ -28,6 +28,19 @@ def handle_internal_server_error(e):
     return render_template('errors/500.html', code=500, message=e), 500
 
 
+def load_if_valid(user, method, src_ip, trust_user = False):
+    try:
+        auth = user.is_validate(method, src_ip, trust_user)
+        if auth == False:
+            return None
+        else:
+            # login_user(user, remember=False)
+            return User.query.filter(User.id==user.id).first()
+    except Exception as e:
+        current_app.logger.error('Error: {0}'.format(e))
+        return None
+
+
 @login_manager.user_loader
 def load_user(id):
     """
@@ -37,29 +50,42 @@ def load_user(id):
 
 
 @login_manager.request_loader
-def login_via_authorization_header(request):
+def login_via_authorization_header_or_remote_user(request):
+    # Try to login using Basic Authentication
     auth_header = request.headers.get('Authorization')
     if auth_header:
+        auth_method = request.args.get('auth_method', 'LOCAL')
+        auth_method = 'LDAP' if auth_method != 'LOCAL' else 'LOCAL'
         auth_header = auth_header.replace('Basic ', '', 1)
         try:
             auth_header = str(base64.b64decode(auth_header), 'utf-8')
             username, password = auth_header.split(":")
         except TypeError as e:
             return None
+
         user = User(username=username,
                     password=password,
                     plain_text_password=password)
-        try:
-            auth_method = request.args.get('auth_method', 'LOCAL')
-            auth_method = 'LDAP' if auth_method != 'LOCAL' else 'LOCAL'
-            auth = user.is_validate(method=auth_method,
-                                    src_ip=request.remote_addr)
-            if auth == False:
-                return None
-            else:
-                # login_user(user, remember=False)
-                return User.query.filter(User.id==user.id).first()
-        except Exception as e:
-            current_app.logger.error('Error: {0}'.format(e))
-            return None
+        return load_if_valid(user, method=auth_method, src_ip=request.remote_addr)
+    
+    # Try login by checking a REMOTE_USER environment variable
+    remote_user = request.remote_user
+    if remote_user and current_app.config.get('REMOTE_USER_ENABLED'):
+        session_remote_user = session.get('remote_user')
+        
+        # If we already validated a remote user against an authorization method
+        # a local user should have been created in the database, so we force a 'LOCAL' auth_method
+        auth_method = 'LOCAL' if session_remote_user else current_app.config.get('REMOTE_AUTH_METHOD', 'LDAP') 
+        current_app.logger.debug(
+            'REMOTE_USER environment variable found: attempting {0} authentication for username "{1}"'
+            .format(auth_method, remote_user))
+        user = User(username=remote_user.strip())
+        valid_remote_user = load_if_valid(user, method=auth_method, src_ip=request.remote_addr, trust_user=True)
+        
+        if valid_remote_user:
+            # If we were successful in authenticating a trusted remote user, store it in session
+            session['remote_user'] = valid_remote_user.username
+
+        return valid_remote_user
+
     return None


### PR DESCRIPTION
- If new `REMOTE_USER_ENABLED` config setting is set to `True`, a username can be provided through a `REMOTE_USER` environment variable, which will be used to login into PowerDNS as a "trusted user".
- A new `LOCAL` user will be created as well and used in subsequent requests. This mimics the existing _Basic Authentication_ flow.
- Allows easy integration with existing SSO providers, such as [CAS](https://github.com/apereo/mod_auth_cas).

New available settings (values shown below are examples, not defaults):

```py
# Whether to enable remote user authentication or not
# Defaults to False
REMOTE_USER_ENABLED=True

# If set, users will be redirected to this location on logout
# Ignore or set to None to avoid redirecting altogether
# Warning: if REMOTE_USER environment variable is still set after logging out and not cleared by
# some external module, not defining a custom logout URL might trigger a loop
# that will just log the user back in right after logging out
REMOTE_USER_LOGOUT_URL=https://my.sso.com/cas/logout

# An optional list of remote authentication tied cookies to be removed upon logout
REMOTE_USER_COOKIES=['MOD_AUTH_CAS', 'MOD_AUTH_CAS_S']
```


This is my first PR here and I'm not really familiar with the overarching architecture of PDNS, so there might be a better/different approach to take here. I'll be happy to revisit the implementation if that's indeed the case.