### PR TITLE
Fix gravatar offline mode

### DIFF
--- a/powerdnsadmin/templates/base.html
+++ b/powerdnsadmin/templates/base.html
@@ -29,7 +29,7 @@
 </head>
 <body class="hold-transition skin-blue sidebar-mini {% if not SETTING.get('fullscreen_layout') %}layout-boxed{% endif %}">
   {% if OFFLINE_MODE %}
-  {% set gravatar_url = "{{ url_for('static', filename='img/gravatar.png') }}" %}
+  {% set gravatar_url = url_for('static', filename='img/gravatar.png') %}
   {% elif current_user.email is defined %}
   {% set gravatar_url = current_user.email|email_to_gravatar_url(size=80) %}
   {% endif %}


### PR DESCRIPTION
After #738 gravatar broke in offline because of incorrect templating at:
https://github.com/ngoduykhanh/PowerDNS-Admin/blob/4e63f8380bd6daa3fe5a651ee6d600be64f6dfd8/powerdnsadmin/templates/base.html#L32
