### PR TITLE
OIDC User and Account management during login

### DIFF
--- a/powerdnsadmin/models/setting.py
+++ b/powerdnsadmin/models/setting.py
@@ -90,6 +90,7 @@ class Setting(db.Model):
         'oidc_oauth_api_url': '',
         'oidc_oauth_token_url': '',
         'oidc_oauth_authorize_url': '',
+        'oidc_oauth_logout_url': '',
         'oidc_oauth_username': 'preferred_username',
         'oidc_oauth_firstname': 'given_name',
         'oidc_oauth_last_name': 'family_name ',

--- a/powerdnsadmin/models/setting.py
+++ b/powerdnsadmin/models/setting.py
@@ -94,6 +94,8 @@ class Setting(db.Model):
         'oidc_oauth_firstname': 'given_name',
         'oidc_oauth_last_name': 'family_name ',
         'oidc_oauth_email': 'email',
+        'oidc_oauth_account_name_property': '',
+        'oidc_oauth_account_description_property': '',
         'forward_records_allow_edit': {
             'A': True,
             'AAAA': True,

--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -473,7 +473,7 @@ class User(db.Model):
         user.email = self.email
 
         # store new password hash (only if changed)
-        if self.plain_text_password != "":
+        if self.plain_text_password:
             user.password = self.get_hashed_password(
                 self.plain_text_password).decode("utf-8")
 

--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -589,3 +589,21 @@ class User(db.Model):
             return {'status': True, 'msg': 'Set user role successfully'}
         else:
             return {'status': False, 'msg': 'Role does not exist'}
+
+    def get_accounts(self):
+        """
+        Get accounts associated with this user
+        """
+        from .account import Account
+        from .account_user import AccountUser
+        accounts = []
+        query = db.session\
+            .query(
+                AccountUser,
+                Account)\
+            .filter(User.id == AccountUser.user_id)\
+            .filter(Account.id == AccountUser.account_id)\
+            .all()
+        for q in query:
+            accounts.append(q[1])
+        return accounts

--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -819,6 +819,10 @@ def setting_authentication():
                               request.form.get('oidc_oauth_last_name'))
                 Setting().set('oidc_oauth_email',
                               request.form.get('oidc_oauth_email'))
+                Setting().set('oidc_oauth_account_name_property',
+                              request.form.get('oidc_oauth_account_name_property'))
+                Setting().set('oidc_oauth_account_description_property',
+                              request.form.get('oidc_oauth_account_description_property'))
                 result = {
                     'status': True,
                     'msg':

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -453,6 +453,13 @@ def logout():
                 session_index=session['samlSessionIndex'],
                 name_id=session['samlNameId']))
 
+    redirect_uri = url_for('index.login')
+    oidc_logout = Setting().get('oidc_oauth_logout_url')
+
+    if 'oidc_token' in session and oidc_logout:
+        redirect_uri = "{}?redirect_uri={}".format(
+            oidc_logout, url_for('index.login', _external=True))
+
     # Clean cookies and flask session
     clear_session()
 
@@ -476,7 +483,7 @@ def logout():
 
         return res
 
-    return redirect(url_for('index.login'))
+    return redirect(redirect_uri)
 
 
 @index_bp.route('/register', methods=['GET', 'POST'])

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -297,11 +297,17 @@ def login():
                         firstname=oidc_givenname,
                         lastname=oidc_familyname,
                         email=oidc_email)
-
             result = user.create_local_user()
-            if not result['status']:
-                session.pop('oidc_token', None)
-                return redirect(url_for('index.login'))
+        else:
+            user.firstname = oidc_givenname
+            user.lastname = oidc_familyname
+            user.email = oidc_email
+            user.plain_text_password = None
+            result = user.update_local_user()
+
+        if not result['status']:
+            session.pop('oidc_token', None)
+            return redirect(url_for('index.login'))
 
         session['user_id'] = user.id
         session['authentication_type'] = 'OAuth'

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -309,6 +309,17 @@ def login():
             session.pop('oidc_token', None)
             return redirect(url_for('index.login'))
 
+        if Setting().get('oidc_oauth_account_name_property') and Setting().get('oidc_oauth_account_description_property'):
+            name_prop = Setting().get('oidc_oauth_account_name_property')
+            desc_prop = Setting().get('oidc_oauth_account_description_property')
+            if name_prop in me and desc_prop in me:
+                account = handle_account(me[name_prop], me[desc_prop])
+                account.add_user(user)
+                user_accounts = user.get_accounts()
+                for ua in user_accounts:
+                    if ua.name != account.name:
+                        ua.remove_user(user)
+
         session['user_id'] = user.id
         session['authentication_type'] = 'OAuth'
         login_user(user, remember=False)
@@ -879,7 +890,7 @@ def create_group_to_account_mapping():
     return group_to_account_mapping
 
 
-def handle_account(account_name):
+def handle_account(account_name, account_description=""):
     clean_name = ''.join(c for c in account_name.lower()
                          if c in "abcdefghijklmnopqrstuvwxyz0123456789")
     if len(clean_name) > Account.name.type.length:
@@ -888,13 +899,16 @@ def handle_account(account_name):
     account = Account.query.filter_by(name=clean_name).first()
     if not account:
         account = Account(name=clean_name.lower(),
-                          description='',
+                          description=account_description,
                           contact='',
                           mail='')
         account.create_account()
         history = History(msg='Account {0} created'.format(account.name),
-                          created_by='SAML Assertion')
+                          created_by='OIDC/SAML Assertion')
         history.add()
+    else:
+        account.description = account_description
+        account.update_account()
     return account
 
 

--- a/powerdnsadmin/templates/admin_setting_authentication.html
+++ b/powerdnsadmin/templates/admin_setting_authentication.html
@@ -502,9 +502,6 @@
                                                     <input type="text" class="form-control" name="oidc_oauth_secret" id="oidc_oauth_secret" placeholder="OIDC OAuth client secret" data-error="Please input Client secret" value="{{ SETTING.get('oidc_oauth_secret') }}">
                                                     <span class="help-block with-errors"></span>
                                                 </div>
-                                            </fieldset>
-                                            <fieldset>
-                                                <legend>ADVANCE</legend>
                                                 <div class="form-group">
                                                     <label for="oidc_oauth_scope">Scope</label>
                                                     <input type="text" class="form-control" name="oidc_oauth_scope" id="oidc_oauth_scope" placeholder="e.g. email" data-error="Please input scope" value="{{ SETTING.get('oidc_oauth_scope') }}">
@@ -546,6 +543,19 @@
                                                 <div class="form-group">
                                                     <label for="oidc_oauth_email">Email</label>
                                                     <input type="text" class="form-control" name="oidc_oauth_email" id="oidc_oauth_email" placeholder="e.g. email" data-error="Plesae input Email claim" value="{{ SETTING.get('oidc_oauth_email') }}">
+                                                    <span class="help-block with-errors"></span>
+                                                </div>
+                                            </fieldset>
+                                            <fieldset>
+                                                <legend>ADVANCE</legend>
+                                                <div class="form-group">
+                                                    <label for="oidc_oauth_account_name_property">Autoprovision Account Name property</label>
+                                                    <input type="text" class="form-control" name="oidc_oauth_account_name_property" id="oidc_oauth_account_name_property" placeholder="e.g. account_name" data-error="Please input property containing account_name" value="{{ SETTING.get('oidc_oauth_account_name_property') }}">
+                                                    <span class="help-block with-errors"></span>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label for="oidc_oauth_account_description_property">Autoprovision Account Description property</label>
+                                                    <input type="text" class="form-control" name="oidc_oauth_account_description_property" id="oidc_oauth_account_description_property" placeholder="e.g. account_description" data-error="Please input property containing account_description" value="{{ SETTING.get('oidc_oauth_account_description_property') }}">
                                                     <span class="help-block with-errors"></span>
                                                 </div>
                                             </fieldset>

--- a/powerdnsadmin/templates/admin_setting_authentication.html
+++ b/powerdnsadmin/templates/admin_setting_authentication.html
@@ -522,6 +522,11 @@
                                                     <input type="text" class="form-control" name="oidc_oauth_authorize_url" id="oidc_oauth_authorize_url" placeholder="e.g. https://oidc.com/login/oauth/authorize" data-error="Plesae input Authorize URL" value="{{ SETTING.get('oidc_oauth_authorize_url') }}">
                                                     <span class="help-block with-errors"></span>
                                                 </div>
+                                                <div class="form-group">
+                                                    <label for="oidc_oauth_logout_url">Logout URL</label>
+                                                    <input type="text" class="form-control" name="oidc_oauth_logout_url" id="oidc_oauth_authorize_url" placeholder="e.g. https://oidc.com/login/oauth/logout" data-error="Please input Logout URL" value="{{ SETTING.get('oidc_oauth_logout_url') }}">
+                                                    <span class="help-block with-errors"></span>
+                                                </div>
                                             </fieldset>
                                             <fieldset>
                                                 <legend>CLAIMS</legend>


### PR DESCRIPTION
This PR adds the following:

1. Update User details on every login.
2. If `oidc_oauth_account_name_property` and `oidc_oauth_account_description_property` are set, automatically create or update an Account during login, and add the User to it.
3. Allows setting of `oidc_oauth_logout_url` to automatically redirect the user to an IdP logout URL, for single logoff .

# Our use case

We store all our user information in an IdP, and can match a User to an Account using just the information returned from the userinfo response. For instance:

```json
{
  "given_name": "Mary",
  "family_name": "Lamb",
...
  "my-customer-id": "customer123",
  "my-customer-name": "Customer 123"
}
```

Setting `oidc_oauth_account_name_property` and `oidc_oauth_account_description_property` to 'my-customer-id' and 'my-customer-name' respectively will make sure that an Account is created (or updated) during login. This allows domains to automatically be mapped to this Account during the next domain sync.