### PR TITLE
do not fail with wildcard PTRs

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -91,7 +91,7 @@ def domain(domain_name):
                 # If it is reverse zone and pretty_ipv6_ptr setting
                 # is enabled, we reformat the name for ipv6 records.
                 if Setting().get('pretty_ipv6_ptr') and r[
-                        'type'] == 'PTR' and 'ip6.arpa' in r_name:
+                        'type'] == 'PTR' and 'ip6.arpa' in r_name and '*' not in r_name:
                     r_name = dns.reversename.to_address(
                         dns.name.from_text(r_name))
 


### PR DESCRIPTION
Hi, 

fixes a bug where PowerDNS-Admin will fail with 500 when

- zone is ipv6
- pretty ptr is enabled
- zone contains wildcards