### PR TITLE
USER instruction enabled in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,22 +74,28 @@ RUN pip install pip-autoremove && \
 # Build image
 FROM alpine:3.11
 
-ENV FLASK_APP=/app/powerdnsadmin/__init__.py
+ENV FLASK_APP=/app/powerdnsadmin/__init__.py \
+    USER=pda
 
-RUN apk add --no-cache mariadb-connector-c postgresql-client py3-gunicorn py3-psycopg2 xmlsec tzdata && \
-    addgroup -S pda && \
-    adduser -S -D -G pda pda && \
+RUN apk add --no-cache mariadb-connector-c postgresql-client py3-gunicorn py3-psycopg2 xmlsec tzdata libcap && \
+    addgroup -S ${USER} && \
+    adduser -S -D -G ${USER} ${USER} && \
     mkdir /data && \
-    chown pda:pda /data
+    chown ${USER}:${USER} /data && \
+    setcap cap_net_bind_service=+ep $(readlink -f /usr/bin/python3) && \
+    apk del libcap
 
 COPY --from=builder /usr/bin/flask /usr/bin/
 COPY --from=builder /usr/lib/python3.8/site-packages /usr/lib/python3.8/site-packages/
-COPY --from=builder --chown=pda:pda /app /app/
+COPY --from=builder --chown=root:${USER} /app /app/
 COPY ./docker/entrypoint.sh /usr/bin/
 
 WORKDIR /app
+RUN chown ${USER}:${USER} ./configs && \
+    cat ./powerdnsadmin/default_config.py ./configs/docker_config.py > ./powerdnsadmin/docker_config.py
 
 EXPOSE 80/tcp
+USER ${USER}
 HEALTHCHECK CMD ["wget","--output-document=-","--quiet","--tries=1","http://127.0.0.1/"]
 ENTRYPOINT ["entrypoint.sh"]
-CMD ["gunicorn","powerdnsadmin:create_app()","--user","pda","--group","pda"]
+CMD ["gunicorn","powerdnsadmin:create_app()"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,13 +7,9 @@ GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
 GUNICORN_LOGLEVEL="${GUNICORN_LOGLEVEL:-info}"
 BIND_ADDRESS="${BIND_ADDRESS:-0.0.0.0:80}"
 
-cat ./powerdnsadmin/default_config.py ./configs/docker_config.py > ./powerdnsadmin/docker_config.py
-
 GUNICORN_ARGS="-t ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKERS} --bind ${BIND_ADDRESS} --log-level ${GUNICORN_LOGLEVEL}"
 if [ "$1" == gunicorn ]; then
-    # run as user pda so that if a SQLite database is generated it is writeable
-    # by that user
-    su pda -s /bin/sh -c "flask db upgrade"
+    /bin/sh -c "flask db upgrade"
     exec "$@" $GUNICORN_ARGS
 
 else


### PR DESCRIPTION
- avoid running gunicorn as root user
- use setcap to allow gunicorn starting with a privileged port
- write permission only on /app/configs folder
- su command removed from entrypoint.sh, because it runs as pda user
- tested with `docker build -f docker/Dockerfile -t powerdns-admin:master .`