### PR TITLE
fix Dockerfile and typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To get started as quickly as possible try option 1. If you want to make modifica
 The easiest is to just run the latest Docker image from Docker Hub:
 ```
 $ docker run -d \
-    -v pda-data:/data
+    -v pda-data:/data \
     -p 9191:80 \
     ngoduykhanh/powerdns-admin:latest
 ```

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,7 @@ GUNICORN_ARGS="-t ${GUNICORN_TIMEOUT} --workers ${GUNICORN_WORKERS} --bind ${BIN
 if [ "$1" == gunicorn ]; then
     # run as user pda so that if a SQLite database is generated it is writeable
     # by that user
+    chown pda:pda /data
     su pda -s /bin/sh -c "flask db upgrade"
     exec "$@" $GUNICORN_ARGS
 


### PR DESCRIPTION
We need to ensure we own our /data dir on every launch since ownership
may change if a new volume is created and/or mounted

Also add a missing backslash in the readme

Signed-off-by: Felix Kaechele <felix@kaechele.ca>