### PR TITLE
Avoid Safari telephone number detection

### DIFF
--- a/powerdnsadmin/templates/base.html
+++ b/powerdnsadmin/templates/base.html
@@ -16,6 +16,8 @@
   {% endif %}
   <!-- Tell the browser to be responsive to screen width -->
   <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+  <!-- Tell Safari to not recognise telephone numbers -->
+  <meta name="format-detection" content="telephone=no">
   {% assets "css_main" -%}
       <link rel="stylesheet" href="{{ ASSET_URL }}">
   {%- endassets %}


### PR DESCRIPTION
Using PowerDNS-Admin on an iPad with Safari can cause incorrect identification of some record data as a telephone number. When submitted, the record with the incorrectly identified data causes an error because of the additional markup present on the submitted data. This was noted in particular with the SOA record. 

The proposed change is to add the Safari meta tag to disable format detection:
https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW5