### PR TITLE
Tweaks to allow  user apikey usage with powerdns terraform provider

### DIFF
--- a/powerdnsadmin/decorators.py
+++ b/powerdnsadmin/decorators.py
@@ -236,7 +236,7 @@ def apikey_can_access_domain(f):
         apikey = g.apikey
         if g.apikey.role.name not in ['Administrator', 'Operator']:
             domains = apikey.domains
-            zone_id = kwargs.get('zone_id')
+            zone_id = kwargs.get('zone_id').rstrip(".")
             domain_names = [item.name for item in domains]
 
             if zone_id not in domain_names:

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -913,7 +913,7 @@ def api_zone_forward(server_id, zone_id):
                                   created_by=g.apikey.description)
                 history.add()
         elif request.method == 'DELETE':
-            history = History(msg='Deleted zone {0}'.format(domain.name),
+            history = History(msg='Deleted zone {0}'.format(zone_id),
                               detail='',
                               created_by=g.apikey.description)
             history.add()

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -919,15 +919,6 @@ def api_zone_forward(server_id, zone_id):
             history.add()
     return resp.content, resp.status_code, resp.headers.items()
 
-
-@api_bp.route('/servers', methods=['GET'])
-@apikey_auth
-@apikey_is_admin
-def api_server_forward():
-    resp = helper.forward_request()
-    return resp.content, resp.status_code, resp.headers.items()
-
-
 @api_bp.route('/servers/<path:subpath>', methods=['GET', 'PUT'])
 @apikey_auth
 @apikey_is_admin
@@ -976,6 +967,18 @@ def api_get_zones(server_id):
         resp = helper.forward_request()
         return resp.content, resp.status_code, resp.headers.items()
 
+
+@api_bp.route('/servers', methods=['GET'])
+@apikey_auth
+def api_server_forward():
+    resp = helper.forward_request()
+    return resp.content, resp.status_code, resp.headers.items()
+
+@api_bp.route('/servers/<string:server_id>', methods=['GET'])
+@apikey_auth
+def api_server_config_forward(server_id):
+    resp = helper.forward_request()
+    return resp.content, resp.status_code, resp.headers.items()
 
 # The endpoint to snychronize Domains in background
 @api_bp.route('/sync_domains', methods=['GET'])


### PR DESCRIPTION
As described in  #844, please find the tweaks I made to allow User api keys to use Terraform Powerdns Provider to create records. (zone creation will obviously not work with user api key.  You have to provide admin Key for that).

Please review this proposal (not sure about creating security issues by opening /servers and /servers/<server_id> (GET only) to non admin users .. (but still registered api key)...

Best Regards, 