### PR TITLE
fix: Follow PDNS Api return format

### DIFF
--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -903,7 +903,7 @@ def api_zone_forward(server_id, zone_id):
     status = resp.status_code
     if 200 <= status < 300:
         current_app.logger.debug("Request to powerdns API successful")
-        if request.method != 'GET' and request.method != 'DELETE':
+        if request.method == 'POST':
             data = request.get_json(force=True)
             for rrset_data in data['rrsets']:
                 history = History(msg='{0} zone {1} record of {2}'.format(
@@ -914,6 +914,11 @@ def api_zone_forward(server_id, zone_id):
                 history.add()
         elif request.method == 'DELETE':
             history = History(msg='Deleted zone {0}'.format(zone_id),
+                              detail='',
+                              created_by=g.apikey.description)
+            history.add()
+        elif request.method != 'GET':
+            history = History(msg='Updated zone {0}'.format(zone_id),
                               detail='',
                               created_by=g.apikey.description)
             history.add()


### PR DESCRIPTION
Closes #857

As you can see in the [official PDNS API doc](https://doc.powerdns.com/authoritative/http-api/zone.html), all requests on the /zone/<zone_id> endpoint returns either 204 "No content" or a 200 "OK" result. Your code tries to extract the rrset data from these blank answers causing the failure.

Still this patch is somehow wrong because I must totally remove the first test anyway as there is no POST method on this endpoint as the doc states now. It may be a breaking change on the last versions of PDNS (I run on 4.3 now) and as you configure a version number in PDNSA you may want to test the configured version to change the behavior.

Let me know, I can slightly change the code.