### PR TITLE
fix: User role was not assigned upon creation

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -431,7 +431,8 @@ class User(db.Model):
             return {'status': False, 'msg': 'Email address is already in use'}
 
         # first register user will be in Administrator role
-        self.role_id = Role.query.filter_by(name='User').first().id
+        if self.role_id is None:
+            self.role_id = Role.query.filter_by(name='User').first().id
         if User.query.count() == 0:
             self.role_id = Role.query.filter_by(
                 name='Administrator').first().id

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -845,7 +845,7 @@ def api_add_account_user(account_id, user_id):
             user.username, account.name))
 
     history = History(
-        msg='Revoke {} user privileges on {}'.format(
+        msg='Add {} user privileges on {}'.format(
             user.username, account.name),
         created_by=current_user.username)
     history.add()


### PR DESCRIPTION
Fixes #859 

This test ensure the role is applied if it is defined when we create a user through the API.

Thank you @ngoduykhanh 