### PR TITLE
feat: Allow sync domain with basic auth

### DIFF
--- a/powerdnsadmin/decorators.py
+++ b/powerdnsadmin/decorators.py
@@ -291,3 +291,13 @@ def dyndns_login_required(f):
         return f(*args, **kwargs)
 
     return decorated_function
+
+def apikey_or_basic_auth(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        api_auth_header = request.headers.get('X-API-KEY')
+        if api_auth_header:
+            return apikey_auth(f)(*args, **kwargs)
+        else:
+            return api_basic_auth(f)(*args, **kwargs)
+    return decorated_function

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -24,6 +24,7 @@ from ..lib.errors import (
 from ..decorators import (
     api_basic_auth, api_can_create_domain, is_json, apikey_auth,
     apikey_is_admin, apikey_can_access_domain, api_role_can,
+    apikey_or_basic_auth,
 )
 import random
 import string
@@ -982,7 +983,7 @@ def api_server_config_forward(server_id):
 
 # The endpoint to snychronize Domains in background
 @api_bp.route('/sync_domains', methods=['GET'])
-@apikey_auth
+@apikey_or_basic_auth
 def sync_domains():
     domain = Domain()
     domain.update()


### PR DESCRIPTION
#847 #848 
Hello @ngoduykhanh 

I have written 2 ansible modules to drive your API: one for managing accounts, one for managing users. I want to show on the output the domains that are associated to the account. 

I create domains through Terraform, so I need to browse the sync_domain endpoint to refresh existing domains so the account is populated with associated domains.

The problem is that your API is split in two parts: 

* The management endpoints in /pdnsadmin is accessed with basic auth
* The PowerDNS proxied endpoint is accessed with an API Key
* The sync_domain endpoint is surprisingly also protected by the API Key

To keep my module consistent (the ones to manage PDNS Admin) I use a traditional user/password setup to browse PDNS Admin API with basic auth. We are also supposed to do so to create the Administrator API key after install. 

I won't ask a user to first create a key, to then update their ansible playbook to add the key to be able to browse /sync_domain endpoint in order to retrieve fresh informations.

This patch implements a generic decorator that allow a fallback to basic on this specific endpoint. As no permission is tested it should be fine. It's an easy option to answer some issues that ask to add api key support on the admin enpoints as well, though some work is intended to replace basic authentication routes permission checking.

What do you think ?
