### PR TITLE
feat: Implement apikeys/<id> endpoint from swagger spec.

### DIFF
--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -390,6 +390,23 @@ def api_get_apikeys(domain_name):
     return json.dumps(apikey_schema.dump(apikeys)), 200
 
 
+@api_bp.route('/pdnsadmin/apikeys/<int:apikey_id>', methods=['GET'])
+@api_basic_auth
+def api_get_apikey(apikey_id):
+    apikey = ApiKey.query.get(apikey_id)
+
+    if not apikey:
+        abort(404)
+
+    current_app.logger.debug(current_user.role.name)
+
+    if current_user.role.name not in ['Administrator', 'Operator']:
+        if apikey_id not in [a.id for a in get_user_apikeys()]:
+            raise DomainAccessForbidden()
+
+    return jsonify(apikey_schema.dump([apikey])[0]), 200
+
+
 @api_bp.route('/pdnsadmin/apikeys/<int:apikey_id>', methods=['DELETE'])
 @api_basic_auth
 def api_delete_apikey(apikey_id):

--- a/powerdnsadmin/swagger-spec.yaml
+++ b/powerdnsadmin/swagger-spec.yaml
@@ -905,6 +905,8 @@ paths:
           description: OK.
           schema:
             $ref: '#/definitions/ApiKey'
+        '403':
+          description: 'The authenticated user has User role and is not allowed on any of the domains assigned to the key'
         '404':
           description: 'Not found. The ApiKey with the specified apikey_id does not exist'
           schema:


### PR DESCRIPTION
@ngoduykhanh 

Hello,

The swagger specs defines a pdnsadmin/apikeys/<key_id> endpoint that was not implemented (it falls back on the /apikeys which return a list of keys instead of a specific key).

Added here