### PR TITLE
upd: improve user api

### DIFF
--- a/powerdnsadmin/lib/errors.py
+++ b/powerdnsadmin/lib/errors.py
@@ -93,6 +93,15 @@ class AccountCreateFail(StructuredException):
         self.name = name
 
 
+class AccountCreateDuplicate(StructuredException):
+    status_code = 409
+
+    def __init__(self, name=None, message="Creation of account failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name
+
+
 class AccountUpdateFail(StructuredException):
     status_code = 500
 
@@ -120,8 +129,24 @@ class UserCreateFail(StructuredException):
         self.name = name
 
 
+class UserCreateDuplicate(StructuredException):
+    status_code = 409
+
+    def __init__(self, name=None, message="Creation of user failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name
+
 class UserUpdateFail(StructuredException):
     status_code = 500
+
+    def __init__(self, name=None, message="Update of user failed"):
+        StructuredException.__init__(self)
+        self.message = message
+        self.name = name
+
+class UserUpdateFailEmail(StructuredException):
+    status_code = 409
 
     def __init__(self, name=None, message="Update of user failed"):
         StructuredException.__init__(self)

--- a/powerdnsadmin/lib/schema.py
+++ b/powerdnsadmin/lib/schema.py
@@ -27,6 +27,11 @@ class ApiPlainKeySchema(Schema):
     plain_key = fields.String()
 
 
+class AccountSummarySchema(Schema):
+    id = fields.Integer()
+    name = fields.String()
+
+
 class UserSchema(Schema):
     id = fields.Integer()
     username = fields.String()
@@ -35,6 +40,14 @@ class UserSchema(Schema):
     email = fields.String()
     role = fields.Embed(schema=RoleSchema)
 
+class UserDetailedSchema(Schema):
+    id = fields.Integer()
+    username = fields.String()
+    firstname = fields.String()
+    lastname = fields.String()
+    email = fields.String()
+    role = fields.Embed(schema=RoleSchema)
+    accounts = fields.Embed(schema=AccountSummarySchema)
 
 class AccountSchema(Schema):
     id = fields.Integer()

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -774,11 +774,6 @@ def api_list_accounts(account_name):
 @api_bp.route('/pdnsadmin/accounts', methods=['POST'])
 @api_basic_auth
 def api_create_account():
-    account_exists = [] or Account.query.filter(Account.name == account_name).all()
-    if len(account_exists) > 0:
-        msg = "Account name already exists"
-        current_app.logger.debug(msg)
-        raise AccountCreateFail(message=msg)
     if current_user.role.name not in ['Administrator', 'Operator']:
         msg = "{} role cannot create accounts".format(current_user.role.name)
         raise NotEnoughPrivileges(message=msg)
@@ -790,6 +785,12 @@ def api_create_account():
     if not name:
         current_app.logger.debug("Account name missing")
         abort(400)
+
+    account_exists = [] or Account.query.filter(Account.name == name).all()
+    if len(account_exists) > 0:
+        msg = "Account {} already exists".format(name)
+        current_app.logger.debug(msg)
+        raise AccountCreateFail(message=msg)
 
     account = Account(name=name,
                       description=description,

--- a/powerdnsadmin/swagger-spec.yaml
+++ b/powerdnsadmin/swagger-spec.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: "0.0.13"
+  version: "0.0.14"
   title: PowerDNS Admin Authoritative HTTP API
   license:
     name: MIT
@@ -1041,6 +1041,10 @@ paths:
           description: Unprocessable Entry, the User data provided has issues
           schema:
             $ref: '#/definitions/Error'
+        '409':
+          description: Duplicate Entry, either the Name or the Email is already in use
+          schema:
+            $ref: '#/definitions/Error'
         '500':
           description: Internal Server Error. There was a problem creating the user
           schema:
@@ -1204,6 +1208,10 @@ paths:
             $ref: '#/definitions/Account'
         '400':
           description: Unprocessable Entry, the Account data provided has issues.
+          schema:
+            $ref: '#/definitions/Error'
+        '409':
+          description: Duplicate Entry, the Name is already in use
           schema:
             $ref: '#/definitions/Error'
         '500':
@@ -1629,10 +1637,7 @@ definitions:
         type: string
         description: 'not used on POST, POSTing to server generates the key material'
       domains:
-        type: array
-        required: false
-        items:
-          $ref: '#/definitions/PDNSAdminZones'
+        $ref: '#/definitions/PDNSAdminZones'
         description: 'domains to which this apikey has access'
       role:
         $ref: '#/definitions/PDNSAdminRole'

--- a/swagger-specv2.yaml
+++ b/swagger-specv2.yaml
@@ -1299,6 +1299,7 @@ paths:
           description: Internal Server Error. Contains error message
           schema:
             $ref: '#/definitions/Error'
+
   '/pdnsadmin/accounts/{account_id}/users':
     parameters:
       - name: account_id
@@ -1629,10 +1630,7 @@ definitions:
         type: string
         description: 'not used on POST, POSTing to server generates the key material'
       domains:
-        type: array
-        required: false
-        items:
-          $ref: '#/definitions/PDNSAdminZones'
+        $ref: '#/definitions/PDNSAdminZones'
         description: 'domains to which this apikey has access'
       role:
         $ref: '#/definitions/PDNSAdminRole'


### PR DESCRIPTION
@ngoduykhanh 

Hello

This PR include multiple changes:
- it changes the output of the user endpoint, so it's in line with the last changes to apikeys and accounts
- it changes the user/account link endpoints to a more logical path accounts/<account_id>/users/<user_id> (the old pattern is not removed but swagger definition has been updated to match the new one)
- it adds account information to users (if you get one, not the list)
- it fixes a bug I introduced in #874
- it introduce a cleaner way to output the results (using lima library to not output json object as a collection instead of tricking jsonify by giving the generated list first item as argument)

~~I need some help because I'm not comfortable with SQLAlchemy. I'd like to add an account property to the User class. I have tried to initialize the accounts field in the init() of the class with the get_accounts() function but it's not working. I do it in the api later but it feels ugly, I'd prefer to have it initialized itself whenever a user is instanciated.~~

This changes makes my terraform provider functional. A bit of work is needed though to correctly handle error codes and output (i.e. trying to create an object with an existing name should not trigger 500 Internal Server Error but 403 Forbidden or 409 Conflict )

Thank you for your time !