### PR TITLE
Bump to Alpine 3.13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 AS builder
+FROM alpine:3.13 AS builder
 LABEL maintainer="k@ndk.name"
 
 ARG BUILD_DEPENDENCIES="build-base \
@@ -8,7 +8,8 @@ ARG BUILD_DEPENDENCIES="build-base \
     openldap-dev \
     python3-dev \
     xmlsec-dev \
-    yarn"
+    yarn \
+    cargo"
 
 ENV LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
@@ -68,12 +69,12 @@ RUN mkdir -p /app && \
 RUN pip install pip-autoremove && \
     pip-autoremove cssmin -y && \
     pip-autoremove jsmin -y && \
-    pip-autoremove pytest -y && \
+    pip-autoremove pytest -y -L packaging && \
     pip uninstall -y pip-autoremove && \
     apk del ${BUILD_DEPENDENCIES}
 
 # Build image
-FROM alpine:3.12
+FROM alpine:3.13
 
 ENV FLASK_APP=/app/powerdnsadmin/__init__.py \
     USER=pda


### PR DESCRIPTION
The docker build was failing due to cryptography 3.4.3 requiring Rust 1.4.5 or later, which isn't available in Alpine 3.12.  This PR bumps the image up to 3.13 and includes cargo to ensure cryptography loads correctly.