### PR TITLE
Update Dockerfile - fix to pip upgrade

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,9 +27,11 @@ WORKDIR /build
 # We copy just the requirements.txt first to leverage Docker cache
 COPY ./requirements.txt /build/requirements.txt
 
+# Update pip
+RUN pip install --upgrade pip
+
 # Get application dependencies
-RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 # Add sources
 COPY . /build


### PR DESCRIPTION
The `pip install --upgrade pip` should be done first in its own RUN. This allows the subsequent `pip install -r` to use the updated `pip`.  If done in the same `RUN` the old version of pip loaded in the environment is used which causes problems for things like `cryptography` requiring rust compilers and such.