### PR TITLE
Emphasize importance of using a custom SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To get started as quickly as possible try option 1. If you want to make modifica
 The easiest is to just run the latest Docker image from Docker Hub:
 ```
 $ docker run -d \
+    -e SECRET_KEY='a-very-secret-key' \
     -v pda-data:/data \
     -p 9191:80 \
     ngoduykhanh/powerdns-admin:latest
@@ -39,10 +40,11 @@ $ docker run -d \
 This creates a volume called `pda-data` to persist the SQLite database with the configuration.
 
 #### Option 2: Using docker-compose
-1. Update the configuration
+1. Update the configuration   
    Edit the `docker-compose.yml` file to update the database connection string in `SQLALCHEMY_DATABASE_URI`.
    Other environment variables are mentioned in the [legal_envvars](https://github.com/ngoduykhanh/PowerDNS-Admin/blob/master/configs/docker_config.py#L5-L46).
-   To use the Docker secrets feature it is possible to append `_FILE` to the environment variables and point to a file with the values stored in it.
+   To use the Docker secrets feature it is possible to append `_FILE` to the environment variables and point to a file with the values stored in it.   
+   Make sure to set the environment variable `SECRET_KEY` to a long random string (https://flask.palletsprojects.com/en/1.1.x/config/#SECRET_KEY)
 
 2. Start docker container
    ```


### PR DESCRIPTION
This project provides a default SECRET_KEY for signing session-cookies:
https://flask.palletsprojects.com/en/1.1.x/config/#SECRET_KEY

By using the default SECRET_KEY, everyone will be able to create valid session-cookies.
So users should be aware that it is very important to set a custom SECRET_KEY.

It would be even better if PowerDNS-Admin would refuse to start if the default SECRET_KEY is used.