### PR TITLE
Add background jobs to docker

### DIFF
--- a/docker/Dockerfile.BackgroundJob
+++ b/docker/Dockerfile.BackgroundJob
@@ -113,7 +113,7 @@ RUN mkdir /etc/services.d/gunicorn && \
 
 # Create service script for cron
 RUN mkdir /etc/services.d/cron && \
-    echo $'#!/usr/bin/execlineb -P\ncrond -f\n' > /etc/services.d/cron/run && \
+    echo $'#!/usr/bin/execlineb -P\nwith-contenv\ncrond -f\n' > /etc/services.d/cron/run && \
     chmod +x /etc/services.d/cron/run
 
 # Add crontab entries

--- a/docker/Dockerfile.BackgroundJob
+++ b/docker/Dockerfile.BackgroundJob
@@ -1,0 +1,110 @@
+FROM alpine:3.13 AS builder
+LABEL maintainer="k@ndk.name"
+
+ARG BUILD_DEPENDENCIES="build-base \
+    libffi-dev \
+    libxml2-dev \
+    mariadb-connector-c-dev \
+    openldap-dev \
+    python3-dev \
+    xmlsec-dev \
+    yarn \
+    cargo"
+
+
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    FLASK_APP=/build/powerdnsadmin/__init__.py
+
+# Get dependencies
+# py3-pip should not belong to BUILD_DEPENDENCIES. Otherwise, when we remove
+# them with "apk del" at the end of build stage, the python requests module
+# will be removed as well - (Tested with alpine:3.12 and python 3.8.5).
+RUN apk add --no-cache ${BUILD_DEPENDENCIES} && \
+    apk add --no-cache py3-pip
+
+WORKDIR /build
+
+# We copy just the requirements.txt first to leverage Docker cache
+COPY ./requirements.txt /build/requirements.txt
+
+# Get application dependencies
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+# Add sources
+COPY . /build
+
+# Prepare assets
+RUN yarn install --pure-lockfile --production && \
+    yarn cache clean && \
+    sed -i -r -e "s|'cssmin',\s?'cssrewrite'|'cssmin'|g" /build/powerdnsadmin/assets.py && \
+    flask assets build
+
+RUN mv /build/powerdnsadmin/static /tmp/static && \
+    mkdir /build/powerdnsadmin/static && \
+    cp -r /tmp/static/generated /build/powerdnsadmin/static && \
+    cp -r /tmp/static/assets /build/powerdnsadmin/static && \
+    cp -r /tmp/static/img /build/powerdnsadmin/static && \
+    find /tmp/static/node_modules -name 'fonts' -exec cp -r {} /build/powerdnsadmin/static \; && \
+    find /tmp/static/node_modules/icheck/skins/square -name '*.png' -exec cp {} /build/powerdnsadmin/static/generated \;
+
+RUN { \
+      echo "from flask_assets import Environment"; \
+      echo "assets = Environment()"; \
+      echo "assets.register('js_login', 'generated/login.js')"; \
+      echo "assets.register('js_validation', 'generated/validation.js')"; \
+      echo "assets.register('css_login', 'generated/login.css')"; \
+      echo "assets.register('js_main', 'generated/main.js')"; \
+      echo "assets.register('css_main', 'generated/main.css')"; \
+    } > /build/powerdnsadmin/assets.py
+
+# Move application
+RUN mkdir -p /app && \
+    cp -r /build/migrations/ /build/powerdnsadmin/ /build/run.py /app && \
+    mkdir -p /app/configs && \
+    cp -r /build/configs/docker_config.py /app/configs
+# Also copy update scripts
+RUN cp /build/update_accounts.py /build/update_zones.py /app/
+
+# Cleanup
+RUN pip install pip-autoremove && \
+    pip-autoremove cssmin -y && \
+    pip-autoremove jsmin -y && \
+    pip-autoremove pytest -y -L packaging && \
+    pip uninstall -y pip-autoremove && \
+    apk del ${BUILD_DEPENDENCIES}
+
+# Build image
+FROM alpine:3.13
+ARG S6_VERSION=v2.2.0.3
+
+ENV FLASK_APP=/app/powerdnsadmin/__init__.py \
+    USER=pda
+
+RUN apk add --no-cache mariadb-connector-c postgresql-client py3-gunicorn py3-psycopg2 xmlsec tzdata libcap && \
+    addgroup -S ${USER} && \
+    adduser -S -D -G ${USER} ${USER} && \
+    mkdir /data && \
+    chown ${USER}:${USER} /data && \
+    setcap cap_net_bind_service=+ep $(readlink -f /usr/bin/python3) && \
+    apk del libcap
+
+COPY --from=builder /usr/bin/flask /usr/bin/
+COPY --from=builder /usr/lib/python3.8/site-packages /usr/lib/python3.8/site-packages/
+COPY --from=builder --chown=root:${USER} /app /app/
+COPY ./docker/entrypoint.sh /usr/bin/
+
+WORKDIR /app
+RUN chown ${USER}:${USER} ./configs /app && \
+    cat ./powerdnsadmin/default_config.py ./configs/docker_config.py > ./powerdnsadmin/docker_config.py
+# Add s6 overlay, so we can manage multiple processes
+ADD https://github.com/just-containers/s6-overlay/releases/download/$S6_VERSION/s6-overlay-amd64-installer /tmp/
+RUN chmod +x /tmp/s6-overlay-amd64-installer && /tmp/s6-overlay-amd64-installer /
+RUN mkdir /etc/services.d/gunicorn && echo $'#!/usr/bin/execlineb -P\nwith-contenv\n' > /etc/services.d/gunicorn/run && echo "s6-setuidgid $USER" >> /etc/services.d/gunicorn/run && echo $'\n/usr/bin/entrypoint.sh gunicorn powerdnsadmin:create_app()' >> /etc/services.d/gunicorn/run && chmod +x /etc/services.d/gunicorn/run
+
+EXPOSE 80/tcp
+#USER ${USER}
+HEALTHCHECK CMD ["wget","--output-document=-","--quiet","--tries=1","http://127.0.0.1/"]
+ENTRYPOINT ["/init"]

--- a/docker/Dockerfile.BackgroundJob
+++ b/docker/Dockerfile.BackgroundJob
@@ -83,7 +83,7 @@ ARG S6_VERSION=v2.2.0.3
 ENV FLASK_APP=/app/powerdnsadmin/__init__.py \
     USER=pda
 
-RUN apk add --no-cache mariadb-connector-c postgresql-client py3-gunicorn py3-psycopg2 xmlsec tzdata libcap && \
+RUN apk add --no-cache mariadb-connector-c postgresql-client py3-gunicorn py3-psycopg2 xmlsec tzdata libcap apk-cron && \
     addgroup -S ${USER} && \
     adduser -S -D -G ${USER} ${USER} && \
     mkdir /data && \
@@ -99,12 +99,27 @@ COPY ./docker/entrypoint.sh /usr/bin/
 WORKDIR /app
 RUN chown ${USER}:${USER} ./configs /app && \
     cat ./powerdnsadmin/default_config.py ./configs/docker_config.py > ./powerdnsadmin/docker_config.py
+
 # Add s6 overlay, so we can manage multiple processes
 ADD https://github.com/just-containers/s6-overlay/releases/download/$S6_VERSION/s6-overlay-amd64-installer /tmp/
 RUN chmod +x /tmp/s6-overlay-amd64-installer && /tmp/s6-overlay-amd64-installer /
-RUN mkdir /etc/services.d/gunicorn && echo $'#!/usr/bin/execlineb -P\nwith-contenv\n' > /etc/services.d/gunicorn/run && echo "s6-setuidgid $USER" >> /etc/services.d/gunicorn/run && echo $'\n/usr/bin/entrypoint.sh gunicorn powerdnsadmin:create_app()' >> /etc/services.d/gunicorn/run && chmod +x /etc/services.d/gunicorn/run
+
+# Create service script for gunicorn
+RUN mkdir /etc/services.d/gunicorn && \
+    echo $'#!/usr/bin/execlineb -P\nwith-contenv\n' > /etc/services.d/gunicorn/run && \
+    echo "s6-setuidgid $USER" >> /etc/services.d/gunicorn/run && \
+    echo $'\n/usr/bin/entrypoint.sh gunicorn powerdnsadmin:create_app()' >> /etc/services.d/gunicorn/run && \
+    chmod +x /etc/services.d/gunicorn/run
+
+# Create service script for cron
+RUN mkdir /etc/services.d/cron && \
+    echo $'#!/usr/bin/execlineb -P\ncrond -f\n' > /etc/services.d/cron/run && \
+    chmod +x /etc/services.d/cron/run
+
+# Add crontab entries
+RUN echo "*/5  *  *  *  * python3 /app/update_zones.py" >> /etc/crontabs/$USER && \
+    echo "*/5  *  *  *  * python3 /app/update_accounts.py" >> /etc/crontabs/$USER
 
 EXPOSE 80/tcp
-#USER ${USER}
 HEALTHCHECK CMD ["wget","--output-document=-","--quiet","--tries=1","http://127.0.0.1/"]
 ENTRYPOINT ["/init"]

--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -104,6 +104,13 @@ def fetch_json(remote_url,
     data = None
     try:
         data = json.loads(r.content.decode('utf-8'))
+    except UnicodeDecodeError:
+        # If the decoding fails, switch to slower but probably working .json()
+        try:
+            logging.warning("UTF-8 content.decode failed, switching to slower .json method")
+            data = r.json()
+        except Exception as e:
+            raise e
     except Exception as e:
         raise RuntimeError(
             'Error while loading JSON data from {0}'.format(remote_url)) from e

--- a/update_accounts.py
+++ b/update_accounts.py
@@ -25,7 +25,9 @@ with app.app_context():
 
     ### Check if bg_domain_updates is set to true
     if not status:
-        app.logger.error('Please turn on "bg_domain_updates" setting to run this job.')
-        sys.exit(1)
+        app.logger.debug('"bg_domain_updates" is disabled, exiting')
+        sys.exit(0)
 
+    ### Start the update process
+    app.logger.info('Update accounts from nameserver API')
     Account().update()

--- a/update_zones.py
+++ b/update_zones.py
@@ -16,7 +16,6 @@ import logging
 from powerdnsadmin import create_app
 from powerdnsadmin.models.domain import Domain
 from powerdnsadmin.models.setting import Setting
-
 app = create_app()
 app.logger.setLevel(logging.INFO)
 
@@ -25,8 +24,8 @@ with app.app_context():
 
     ### Check if bg_domain_updates is set to true
     if not status:
-        app.logger.error('Please turn on "bg_domain_updates" setting to run this job.')
-        sys.exit(1)
+        app.logger.debug('"bg_domain_updates" is disabled, exiting')
+        sys.exit(0)
 
     ### Start the update process
     app.logger.info('Update domains from nameserver API')


### PR DESCRIPTION
#939 

This changes the files "update_zones.py" and "update_accounts.py" slightly, changing the error message to lower priority. It also moves them to the powerdnsadmin directory inside the docker image.

A new Dockerfile "Dockerfile.BackgroundJob" is created. This docker image differs from the stock one provided by including the s6-overlay https://github.com/just-containers/s6-overlay 
That way, a cron instance can be started next to PowerDNS-Admin.

Using that, the Docker Image will automatically update Zones and Accounts every 5 minutes if the "bg_domain_updates" setting is enabled.

TLDR:
Have Dockerfile with background jobs