### PR TITLE
setting account_user_ids to empty list on GET /account/edit

### DIFF
--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -440,6 +440,7 @@ def edit_account(account_name=None):
     if request.method == 'GET':
         if account_name is None:
             return render_template('admin_edit_account.html',
+                                   account_user_ids=[],
                                    users=users,
                                    create=1)
 


### PR DESCRIPTION
This sets account_user_ids to empty list, preventing jinja exception

```
def edit_account(account_name=None):
    users = User.query.all()

    if request.method == 'GET':
        if account_name is None:
            return render_template('admin_edit_account.html',
                                   users=users,
                                   account_user_ids=[],
                                   create=1)
```
That should fix #937 