### PR TITLE
fix: actually store OIDC logout URL

### DIFF
--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -986,6 +986,8 @@ def setting_authentication():
                               request.form.get('oidc_oauth_token_url'))
                 Setting().set('oidc_oauth_authorize_url',
                               request.form.get('oidc_oauth_authorize_url'))
+                Setting().set('oidc_oauth_logout_url',
+                              request.form.get('oidc_oauth_logout_url'))
                 Setting().set('oidc_oauth_username',
                               request.form.get('oidc_oauth_username'))
                 Setting().set('oidc_oauth_firstname',

--- a/powerdnsadmin/templates/admin_setting_authentication.html
+++ b/powerdnsadmin/templates/admin_setting_authentication.html
@@ -626,7 +626,7 @@
                                                 </div>
                                                 <div class="form-group">
                                                     <label for="oidc_oauth_logout_url">Logout URL</label>
-                                                    <input type="text" class="form-control" name="oidc_oauth_logout_url" id="oidc_oauth_authorize_url" placeholder="e.g. https://oidc.com/login/oauth/logout" data-error="Please input Logout URL" value="{{ SETTING.get('oidc_oauth_logout_url') }}">
+                                                    <input type="text" class="form-control" name="oidc_oauth_logout_url" id="oidc_oauth_logout_url" placeholder="e.g. https://oidc.com/login/oauth/logout" data-error="Please input Logout URL" value="{{ SETTING.get('oidc_oauth_logout_url') }}">
                                                     <span class="help-block with-errors"></span>
                                                 </div>
                                             </fieldset>


### PR DESCRIPTION
This correctly saves the value, but I have not been able to validate
that it actually properly calls the IDP logout URL with the desired effect.
This is due to other issues with the OIDC feature and my IDP.