### PR TITLE
bg_domain button for operators and higher

### DIFF
--- a/powerdnsadmin/routes/dashboard.py
+++ b/powerdnsadmin/routes/dashboard.py
@@ -3,6 +3,7 @@ from flask import Blueprint, render_template, url_for, current_app, request, jso
 from flask_login import login_required, current_user, login_manager
 from sqlalchemy import not_
 
+from ..decorators import operator_role_required
 from ..lib.utils import customBoxes
 from ..models.user import User, Anonymous
 from ..models.account import Account
@@ -150,6 +151,10 @@ def dashboard():
     else:
         current_app.logger.info('Updating domains in background...')
 
+    show_bg_domain_button = BG_DOMAIN_UPDATE
+    if BG_DOMAIN_UPDATE and current_user.role.name not in ['Administrator', 'Operator']:
+        show_bg_domain_button = False
+
     # Stats for dashboard
     domain_count = 0
     history_number = 0
@@ -198,12 +203,13 @@ def dashboard():
                            history_number=history_number,
                            uptime=uptime,
                            histories=history,
-                           show_bg_domain_button=BG_DOMAIN_UPDATE,
+                           show_bg_domain_button=show_bg_domain_button,
                            pdns_version=Setting().get('pdns_version'))
 
 
 @dashboard_bp.route('/domains-updater', methods=['GET', 'POST'])
 @login_required
+@operator_role_required
 def domains_updater():
     current_app.logger.debug('Update domains in background')
     d = Domain().update()


### PR DESCRIPTION
The background domain sync can be take alot of time when theres alot of domains, this is why there is a setting to sync the domain manually instead of syncing it in the background for each http request.
Now the button and the API is open for every authenticated user.
This create a problem - we know the request can take alot of time but we still give regular users the power to initiate such process. This API can be easily abusable by malicious users and can cause performance degradation or even denial of service.
This pull request limit the API (and showing the button) to only users with operator role or higher, which we know we can probably truest.