### PR TITLE
fix: Accounts API is broken

### DIFF
--- a/powerdnsadmin/lib/schema.py
+++ b/powerdnsadmin/lib/schema.py
@@ -47,7 +47,7 @@ class UserDetailedSchema(Schema):
     lastname = fields.String()
     email = fields.String()
     role = fields.Embed(schema=RoleSchema)
-    accounts = fields.Embed(schema=AccountSummarySchema)
+    accounts = fields.Embed(schema=AccountSummarySchema, many=True)
 
 class AccountSchema(Schema):
     id = fields.Integer()


### PR DESCRIPTION
Retrieving an account from the API is broken, it just fails, because added accounts key is a list, requiring many=True option