### PR TITLE
Remove unnecessary build step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,14 +65,6 @@ RUN mkdir -p /app && \
     mkdir -p /app/configs && \
     cp -r /build/configs/docker_config.py /app/configs
 
-# Cleanup
-RUN pip install pip-autoremove && \
-    pip-autoremove cssmin -y && \
-    pip-autoremove jsmin -y && \
-    pip-autoremove pytest -y -L packaging && \
-    pip uninstall -y pip-autoremove && \
-    apk del ${BUILD_DEPENDENCIES}
-
 # Build image
 FROM alpine:3.13
 


### PR DESCRIPTION
The builder image does not need to cleanup itself, 
the whole purpose of it is to be dropped after the final artifacts are copied out.