### PR TITLE
fix: jsmin 2.2.2 no longer available. Use 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ python3-saml
 pyOpenSSL==19.1.0
 pytz==2020.1
 cssmin==0.2.0
-jsmin==2.2.2
+jsmin==3.0.0
 Authlib==0.15
 Flask-SeaSurf==0.2.2
 bravado-core==5.17.0


### PR DESCRIPTION
We can't deploy anymore because the 2.2.2 version have dependencies that are no longer available in pip. Using this version (the author just removed the obsolete library usage to create the 3.0.0 version) let us install PDNSA.