### PR TITLE
default config: add exemplary URL encoding step for SQLA DB URL params

### DIFF
--- a/configs/development.py
+++ b/configs/development.py
@@ -1,5 +1,6 @@
 import os
-basedir = os.path.abspath(os.path.abspath(os.path.dirname(__file__)))
+#import urllib.parse
+basedir = os.path.abspath(os.path.dirname(__file__))
 
 ### BASIC APP CONFIG
 SALT = '$2b$12$yLUMTIfl21FKJQpTkRQXCu'
@@ -16,7 +17,12 @@ SQLA_DB_NAME = 'pda'
 SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 ### DATABASE - MySQL
-# SQLALCHEMY_DATABASE_URI = 'mysql://' + SQLA_DB_USER + ':' + SQLA_DB_PASSWORD + '@' + SQLA_DB_HOST + '/' + SQLA_DB_NAME
+#SQLALCHEMY_DATABASE_URI = 'mysql://{}:{}@{}/{}'.format(
+#    urllib.parse.quote_plus(SQLA_DB_USER),
+#    urllib.parse.quote_plus(SQLA_DB_PASSWORD),
+#    SQLA_DB_HOST,
+#    SQLA_DB_NAME
+#)
 
 ### DATABASE - SQLite
 SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'pdns.db')

--- a/configs/test.py
+++ b/configs/test.py
@@ -1,5 +1,5 @@
 import os
-basedir = os.path.abspath(os.path.abspath(os.path.dirname(__file__)))
+basedir = os.path.abspath(os.path.dirname(__file__))
 
 ### BASIC APP CONFIG
 SALT = '$2b$12$yLUMTIfl21FKJQpTkRQXCu'

--- a/powerdnsadmin/default_config.py
+++ b/powerdnsadmin/default_config.py
@@ -1,5 +1,6 @@
 import os
-basedir = os.path.abspath(os.path.abspath(os.path.dirname(__file__)))
+import urllib.parse
+basedir = os.path.abspath(os.path.dirname(__file__))
 
 ### BASIC APP CONFIG
 SALT = '$2b$12$yLUMTIfl21FKJQpTkRQXCu'
@@ -18,7 +19,12 @@ SQLA_DB_NAME = 'pda'
 SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 ### DATABASE - MySQL
-SQLALCHEMY_DATABASE_URI = 'mysql://'+SQLA_DB_USER+':'+SQLA_DB_PASSWORD+'@'+SQLA_DB_HOST+'/'+SQLA_DB_NAME
+SQLALCHEMY_DATABASE_URI = 'mysql://{}:{}@{}/{}'.format(
+    urllib.parse.quote_plus(SQLA_DB_USER),
+    urllib.parse.quote_plus(SQLA_DB_PASSWORD),
+    SQLA_DB_HOST,
+    SQLA_DB_NAME
+)
 
 ### DATABASE - SQLite
 # SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'pdns.db')


### PR DESCRIPTION
SQLAlchemy database URLs follow RFC-1738, so parameters like username
and password need to be encoded accordingly.

https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls

---

See https://github.com/ngoduykhanh/PowerDNS-Admin/issues/1036.