### PR TITLE
models.user: get_accounts(): order by name

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -628,6 +628,7 @@ class User(db.Model):
                 Account)\
             .filter(self.id == AccountUser.user_id)\
             .filter(Account.id == AccountUser.account_id)\
+            .order_by(Account.name)\
             .all()
         for q in query:
             accounts.append(q[1])


### PR DESCRIPTION
The order of account names returned by `User.get_accounts()` affects the order account names are displyed in on /domain/add if the current user neither has the Administrator role nor the Operator role and the `allow_user_create_domain` setting is enabled at the same time.

If the current user does have the Administrator or Operator role, `routes.domain.add()` already returns accounts ordered by name, so this change makes it consistent.