### PR TITLE
fix: Check user zone create/delete permission

### DIFF
--- a/powerdnsadmin/decorators.py
+++ b/powerdnsadmin/decorators.py
@@ -246,6 +246,45 @@ def api_can_create_domain(f):
     return decorated_function
 
 
+def apikey_can_create_domain(f):
+    """
+    Grant access if:
+        - user is in Operator role or higher, or
+        - allow_user_create_domain is on
+    """
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if g.apikey.role.name not in [
+                'Administrator', 'Operator'
+        ] and not Setting().get('allow_user_create_domain'):
+            msg = "ApiKey #{0} does not have enough privileges to create domain"
+            current_app.logger.error(msg.format(g.apikey.id))
+            raise NotEnoughPrivileges()
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
+def apikey_can_remove_domain(f):
+    """
+    Grant access if:
+        - user is in Operator role or higher, or
+        - allow_user_remove_domain is on
+    """
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if (request.method == 'DELETE' and
+            g.apikey.role.name not in [
+                'Administrator', 'Operator'
+        ] and not Setting().get('allow_user_remove_domain')):
+            msg = "ApiKey #{0} does not have enough privileges to remove domain"
+            current_app.logger.error(msg.format(g.apikey.id))
+            raise NotEnoughPrivileges()
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
 def apikey_is_admin(f):
     """
     Grant access if user is in Administrator role

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -27,8 +27,7 @@ from ..lib.errors import (
 )
 from ..decorators import (
     api_basic_auth, api_can_create_domain, is_json, apikey_auth,
-    apikey_can_create_domain, apikey_can_remove_domain,
-    apikey_is_admin, apikey_can_access_domain,
+    apikey_can, apikey_is_admin, apikey_can_access_domain,
     api_role_can, apikey_or_basic_auth,
 )
 import random
@@ -972,7 +971,7 @@ def api_zone_subpath_forward(server_id, zone_id, subpath):
               methods=['GET', 'PUT', 'PATCH', 'DELETE'])
 @apikey_auth
 @apikey_can_access_domain
-@apikey_can_remove_domain
+@apikey_can('remove_domain', http_methods=['DELETE'])
 def api_zone_forward(server_id, zone_id):
     resp = helper.forward_request()
     if not Setting().get('bg_domain_updates'):
@@ -1016,7 +1015,7 @@ def api_server_sub_forward(subpath):
 
 @api_bp.route('/servers/<string:server_id>/zones', methods=['POST'])
 @apikey_auth
-@apikey_can_create_domain
+@apikey_can('create_domain', http_methods=['POST'])
 def api_create_zone(server_id):
     resp = helper.forward_request()
 

--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -27,8 +27,9 @@ from ..lib.errors import (
 )
 from ..decorators import (
     api_basic_auth, api_can_create_domain, is_json, apikey_auth,
-    apikey_is_admin, apikey_can_access_domain, api_role_can,
-    apikey_or_basic_auth,
+    apikey_can_create_domain, apikey_can_remove_domain,
+    apikey_is_admin, apikey_can_access_domain,
+    api_role_can, apikey_or_basic_auth,
 )
 import random
 import string
@@ -971,6 +972,7 @@ def api_zone_subpath_forward(server_id, zone_id, subpath):
               methods=['GET', 'PUT', 'PATCH', 'DELETE'])
 @apikey_auth
 @apikey_can_access_domain
+@apikey_can_remove_domain
 def api_zone_forward(server_id, zone_id):
     resp = helper.forward_request()
     if not Setting().get('bg_domain_updates'):
@@ -1014,6 +1016,7 @@ def api_server_sub_forward(subpath):
 
 @api_bp.route('/servers/<string:server_id>/zones', methods=['POST'])
 @apikey_auth
+@apikey_can_create_domain
 def api_create_zone(server_id):
     resp = helper.forward_request()
 


### PR DESCRIPTION
Hello,

I was looking at the API code to update the Swagger definition and I saw that the options allowing a user to create or remove a domain are checked on the /powerdnsadmin/zones endpoint but not on the /servers/localhost/zones endpoint.

These two decorators do the check.