### PR TITLE
fix: Error in the swagger AccountSummary definition

### DIFF
--- a/powerdnsadmin/swagger-spec.yaml
+++ b/powerdnsadmin/swagger-spec.yaml
@@ -2031,11 +2031,8 @@ definitions:
         description: The name for this account (unique, immutable)
         readOnly: false
       domains:
-        type: array
         description: The list of domains owned by this account
-        readOnly: true
-        items:
-          $ref: '#/definitions/PDNSAdminZones'
+        $ref: '#/definitions/PDNSAdminZones'
 
   ConfigSetting:
     title: ConfigSetting


### PR DESCRIPTION
Hello,

It may be a detail but i couldn't generate a client that works with the old definition. It waited for a list of list of dicts because the referenced object is already a list.

Regards