### PR TITLE
Fix rrset changelog for names with hyphen

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -277,7 +277,7 @@ def changelog(domain_name):
 """
 Returns a changelog for a specific pair of (record_name, record_type)
 """
-@domain_bp.route('/<path:domain_name>/changelog/<path:record_name>-<path:record_type>', methods=['GET'])
+@domain_bp.route('/<path:domain_name>/changelog/<path:record_name>/<string:record_type>', methods=['GET'])
 @login_required
 @can_access_domain
 @history_access_required

--- a/powerdnsadmin/templates/domain.html
+++ b/powerdnsadmin/templates/domain.html
@@ -190,7 +190,7 @@
 
     function show_record_changelog(record_name, record_type, e) {
         e.stopPropagation();
-        window.location.href = "/domain/{{domain.name}}/changelog/" + record_name + ".-" + record_type;
+        window.location.href = "/domain/{{domain.name}}/changelog/" + record_name + "./" + record_type;
     }
     // handle changelog button
     $(document.body).on("click", ".button_changelog", function(e) {


### PR DESCRIPTION
When clicking the changelog button for a record with the name `foo-bar.example.org`, the url you get redirected to is `/domain/example.org/changelog/foo-bar.example.org.-A`. Because of the non-greedy behaviour of the path converter, the last part gets split at the *first* hyphen, so the example above gets wrongly dissected into `record_name=foo` and `record_type=bar.example.org.-A`. This results for obvious reasons in an empty changelog.

As described in [rfc5395](https://datatracker.ietf.org/doc/html/rfc5395#section-3.1), types have to be alphanumerical, so its converter is changed from path to string.

The hyphen is one of the few characters recommended by [rfc1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1), so it is a bad choice as separator. The separator is instead changed to a slash.
Granted, this does not entirely solve the issue but at least makes it a lot less likely to happen. Plus, a lot more and other things break in pda with slashes in domain-/record-names.