### PR TITLE
Activity page history base_query unification and perfomance gain

### DIFF
--- a/powerdnsadmin/routes/domain.py
+++ b/powerdnsadmin/routes/domain.py
@@ -235,14 +235,14 @@ def changelog(domain_name):
             ).all()
 
     if StrictVersion(Setting().get('pdns_version')) >= StrictVersion('4.0.0'):
+        pretty_v6 = Setting().get('pretty_ipv6_ptr')
         for r in rrsets:
             if r['type'] in records_allow_to_edit:
                 r_name = r['name'].rstrip('.')
 
                 # If it is reverse zone and pretty_ipv6_ptr setting
                 # is enabled, we reformat the name for ipv6 records.
-                if Setting().get('pretty_ipv6_ptr') and r[
-                        'type'] == 'PTR' and 'ip6.arpa' in r_name and '*' not in r_name:
+                if pretty_v6 and r['type'] == 'PTR' and 'ip6.arpa' in r_name and '*' not in r_name:
                     r_name = dns.reversename.to_address(
                         dns.name.from_text(r_name))
 


### PR DESCRIPTION
### Fixes: #1486 

Cleaned up the history_table() sqlalchemy query composing by forcing use of base_query. Performance impovement to resolve #1486 is already familiar in this project.