### PR TITLE
fix: oidc userinfo endpoint

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -392,7 +392,7 @@ def login():
         return authenticate_user(user, 'Azure OAuth')
 
     if 'oidc_token' in session:
-        user_data = json.loads(oidc.get('userinfo').text)
+        user_data = oidc.userinfo()
         oidc_username = user_data[Setting().get('oidc_oauth_username')]
         oidc_first_name = user_data[Setting().get('oidc_oauth_firstname')]
         oidc_last_name = user_data[Setting().get('oidc_oauth_last_name')]


### PR DESCRIPTION
This PR solves OIDC userinfo endpoint.

Indeed, currently, code supposes userinfo endpoint is always api base Url + `/userinfo`. However, it is not always the case. Instead, OAuth2 client must source this information from metadata. It's exactly what userinfo() methods does.