### PR TITLE
Remove leading slash

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -67,7 +67,7 @@ jobs:
           context: ./
           file: ./docker/Dockerfile
           push: true
-          tags: powerdnsadmin/pda-legacy:${{ github.ref_name }}
+          tags: john0222/pda-legacy:${{ github.ref_name }}
 
       - name: Docker Image Release Tagging
         uses: docker/build-push-action@v4

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            powerdnsadmin/pda-legacy
+            john0222/pda-legacy
           tags: |
             type=ref,event=tag
             type=semver,pattern={{version}}

--- a/powerdnsadmin/lib/utils.py
+++ b/powerdnsadmin/lib/utils.py
@@ -189,7 +189,7 @@ def pdns_api_extended_uri(version):
     Check the pdns version
     """
     if StrictVersion(version) >= StrictVersion('4.0.0'):
-        return "/api/v1"
+        return "api/v1"
     else:
         return ""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,9 @@ pyasn1==0.4.8
 pyotp==2.8.0
 pytest==7.4.4
 python-ldap==3.4.3
-python3-saml==1.15.0
+python3-saml==1.16.0
+lxml==5.2.1
+xmlsec==1.3.14
 pytimeparse==1.1.8
 pytz==2022.7.1
 qrcode==7.3.1


### PR DESCRIPTION
Remove the leading slash to let dns gui connect to powerdns servers which are behind a proxy under subpath.

Fixes the issue to connect to PowerDNS instances behind a proxy which lives under a subpath.

The old code behaves like this when you enter a url:

Example 1 (breaks the url):

`
urljoin('https://dns.example.com/pdns-authoritative', '/api/v1' + '/servers/localhost/zones')
'https://dns.example.com/api/v1/servers/localhost/zones'
`
Example 2 (breaks the url):
`
urljoin('https://dns.example.com/pdns-authoritative/', '/api/v1' + '/servers/localhost/zones')
'https://dns.example.com/api/v1/servers/localhost/zones'
`

The proposed change fixes it

Example 1 (keeps the url):

`
urljoin('https://dns.example.com/pdns-authoritative/', 'api/v1' + '/servers/localhost/zones')
'https://dns.example.com/pdns-authoritative/api/v1/servers/localhost/zones'
`

In case some entered the url without a trailing slash, it would break existing deployed applications.