### PR TITLE
Sync zone catalog changes from PowerDNS

### DIFF
--- a/powerdnsadmin/models/domain.py
+++ b/powerdnsadmin/models/domain.py
@@ -201,6 +201,8 @@ class Domain(db.Model):
             return {'status': 'error', 'msg': 'Cannot update zone table'}
 
     def update_pdns_admin_domain(self, domain, account_id, data, do_commit=True):
+        catalog = (data.get('catalog') or '').rstrip('.') or None
+
         # existing domain, only update if something actually has changed
         if (domain.master != str(data['masters'])
                 or domain.type != data['kind']
@@ -208,11 +210,13 @@ class Domain(db.Model):
                 or domain.notified_serial != data['notified_serial']
                 or domain.last_check != (1 if data['last_check'] else 0)
                 or domain.dnssec != data['dnssec']
+                or domain.catalog != catalog
                 or domain.account_id != account_id):
 
             domain.master = str(data['masters'])
             domain.type = data['kind']
             domain.serial = data['serial']
+            domain.catalog = catalog
             domain.notified_serial = data['notified_serial']
             domain.last_check = 1 if data['last_check'] else 0
             domain.dnssec = 1 if data['dnssec'] else 0

--- a/tests/unit/test_zone_catalog.py
+++ b/tests/unit/test_zone_catalog.py
@@ -1,9 +1,39 @@
 import re
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from powerdnsadmin.models.domain import Domain
 from powerdnsadmin.models.user import User
+
+
+def test_zone_sync_updates_catalog_for_existing_zone(app):
+    domain = SimpleNamespace(
+        name='member.example',
+        master='[]',
+        type='NATIVE',
+        serial=1,
+        notified_serial=1,
+        last_check=0,
+        dnssec=0,
+        catalog='old-catalog.example',
+        account_id=None,
+    )
+    data = {
+        'masters': [],
+        'kind': 'NATIVE',
+        'serial': 1,
+        'notified_serial': 1,
+        'last_check': False,
+        'dnssec': False,
+        'catalog': 'new-catalog.example.',
+    }
+
+    with app.app_context():
+        Domain.update_pdns_admin_domain(
+            None, domain, account_id=None, data=data, do_commit=False)
+
+    assert domain.catalog == 'new-catalog.example'
 
 
 def test_zone_creation_without_catalog_is_backward_compatible(initial_data,


### PR DESCRIPTION
This updates the zone synchronization logic to keep the local catalog assignment in sync with PowerDNS.

Previously, Domain.update() updated the existing zone properties but did not update catalog. As a result, catalog changes made directly in PowerDNS could leave the local database with outdated information.

The update also handles missing or empty catalog fields safely and normalizes trailing dots. A regression test has been added for updating the catalog of an existing zone.

I was unable to open an issue for this change because issue creation is currently unavailable in the repository.