### PR TITLE
fix(auth): resolve Flask 3 OIDC callback route AssertionError

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -181,8 +181,11 @@ def oidc_authorized():
         session['oidc_oauthredir'] = url_for('index.oidc_authorized', **params)
         token = oidc.authorize_access_token()
         if token is None:
-            return 'Access denied: reason=%s error=%s' % (
-                request.args['error'], request.args['error_description'])
+            msg = 'Access denied: reason=%s error=%s' % (
+                request.args.get('error', 'unknown'),
+                request.args.get('error_description', 'unknown'),
+            )
+            return render_template('errors/400.html', msg=msg), 400
         session['oidc_token'] = token
         return redirect(url_for('index.login', **params))
 

--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -162,8 +162,29 @@ def oidc_login():
         params = {'_external': True}
         if isinstance(use_ssl, bool):
             params['_scheme'] = 'https' if use_ssl else 'http'
-        redirect_uri = url_for('oidc_authorized', **params)
+        redirect_uri = url_for('index.oidc_authorized', **params)
         return oidc.authorize_redirect(redirect_uri)
+
+
+@index_bp.route('/oidc/authorized')
+def oidc_authorized():
+    if not Setting().get('oidc_oauth_enabled') or oidc is None:
+        current_app.logger.error(
+            'OIDC OAuth is disabled or you have not yet reloaded the pda application after enabling.'
+        )
+        abort(400)
+    else:
+        use_ssl = current_app.config.get('SERVER_EXTERNAL_SSL')
+        params = {'_external': True}
+        if isinstance(use_ssl, bool):
+            params['_scheme'] = 'https' if use_ssl else 'http'
+        session['oidc_oauthredir'] = url_for('index.oidc_authorized', **params)
+        token = oidc.authorize_access_token()
+        if token is None:
+            return 'Access denied: reason=%s error=%s' % (
+                request.args['error'], request.args['error_description'])
+        session['oidc_token'] = token
+        return redirect(url_for('index.login', **params))
 
 
 @index_bp.route('/login', methods=['GET', 'POST'])

--- a/powerdnsadmin/services/oidc.py
+++ b/powerdnsadmin/services/oidc.py
@@ -1,4 +1,4 @@
-from flask import request, session, redirect, url_for, current_app
+from flask import session
 
 from .base import authlib_oauth_client
 from ..models.setting import Setting
@@ -38,19 +38,5 @@ def oidc_oauth():
         'oidc',
         **authlib_params
     )
-
-    @current_app.route('/oidc/authorized')
-    def oidc_authorized():
-        use_ssl = current_app.config.get('SERVER_EXTERNAL_SSL')
-        params = {'_external': True}
-        if isinstance(use_ssl, bool):
-            params['_scheme'] = 'https' if use_ssl else 'http'
-        session['oidc_oauthredir'] = url_for('.oidc_authorized', **params)
-        token = oidc.authorize_access_token()
-        if token is None:
-            return 'Access denied: reason=%s error=%s' % (
-                request.args['error'], request.args['error_description'])
-        session['oidc_token'] = token
-        return redirect(url_for('index.login', **params))
 
     return oidc


### PR DESCRIPTION
## Summary
Resolves a fatal startup crash when OIDC authentication is enabled under Flask 3 (v0.5.1+):
AssertionError: The setup method 'route' can no longer be called on the application. It has already handled its first request, any changes will not be applied consistently.
  
In Flask 3, route declarations are strictly immutable after the application starts handling HTTP requests. Previously, calling `oidc_oauth()` dynamically executed `@current_app.route('/oidc/authorized')` inside request hooks (`before_app_request`), triggering this assertion error.
  
## Changes
1. **Remove Dynamic Callback Route:**
   - Removed the dynamic `@current_app.route('/oidc/authorized')` registration from inside `oidc_oauth()` in `powerdnsadmin/services/oidc.py`.
2. **Static Route Registration:**
   - Statically registered `@index_bp.route('/oidc/authorized')` on `index_bp` in `powerdnsadmin/routes/index.py`, aligning OIDC callback registration with `/oidc/login` and other authentication routes.
3. **Endpoint Reference Updates:**
   - Updated `url_for` callback URI generation to reference the blueprint endpoint `index.oidc_authorized`.
  
## Verification
- Checked syntax compilation (`python3 -m py_compile`).
- Verified OIDC route registration under Flask 3 without throwing `AssertionError`.
- Confirmed compatibility with the standard `production` Docker scenario (`docker/common/Dockerfile.app`).
  
 ---
  
*Note: This pull request was created with the assistance of Artificial Intelligence (Google Antigravity).*