### PR TITLE
add mysql powerdns schema presence to healthcheck

### DIFF
--- a/docker/docker-compose-browser-test.yml
+++ b/docker/docker-compose-browser-test.yml
@@ -67,7 +67,7 @@ services:
     tmpfs:
       - /var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent && mysql -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent --skip-column-names -e \"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='powerdns' AND table_name IN ('domains','records','comments')\" | grep -q '^3$'"]
       interval: 2s
       timeout: 5s
       retries: 30

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -100,7 +100,7 @@ services:
       - powerdns-admin-dev-mysql:/var/lib/mysql
       - ./common/mysql-init.sql:/docker-entrypoint-initdb.d/10-powerdns.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent && mysql -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent --skip-column-names -e \"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='powerdns' AND table_name IN ('domains','records','comments')\" | grep -q '^3$'"]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/docker/docker-compose-test.yml
+++ b/docker/docker-compose-test.yml
@@ -63,7 +63,7 @@ services:
     tmpfs:
       - /var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent && mysql -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent --skip-column-names -e \"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='powerdns' AND table_name IN ('domains','records','comments')\" | grep -q '^3$'"]
       interval: 2s
       timeout: 5s
       retries: 30


### PR DESCRIPTION


## Related issue

Closes #1873

## Summary

when running test suites on my machine, it hangs on pdns connecting to mysql. 

## Testing



- [x] Existing automated tests pass.
- [x] New or changed behavior has relevant automated coverage.
- [x] UI changes were checked in supported browsers and color modes.

## Impact

test suite reliability

## Screenshots

not applicable

## Changelog

add powerdns schema presence test to mysql in healthcheck.

Category: test suites

