### PR TITLE
fix(auth): preserve password hash when saving profile with empty value

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -466,7 +466,7 @@ class User(db.Model):
                 name='Administrator').first().id
 
         if hasattr(self, "plain_text_password"):
-            if self.plain_text_password != None:
+            if self.plain_text_password:
                 self.password = self.get_hashed_password(
                     self.plain_text_password)
         else:
@@ -521,7 +521,7 @@ class User(db.Model):
 
         # store new password hash (only if changed)
         if hasattr(self, "plain_text_password"):
-            if self.plain_text_password != None:
+            if self.plain_text_password:
                 user.password = self.get_hashed_password(
                     self.plain_text_password).decode("utf-8")
 
@@ -540,7 +540,7 @@ class User(db.Model):
         user.lastname = self.lastname if self.lastname else user.lastname
 
         if hasattr(self, "plain_text_password"):
-            if self.plain_text_password != None:
+            if self.plain_text_password:
                 user.password = self.get_hashed_password(
                  self.plain_text_password).decode("utf-8")
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

An empty password field on profile save passed the `!= None` check and
overwrote the stored hash with a hash of ''. Use a truthiness check so
None and '' both mean "no new password" and the hash is kept.

## Testing

<!-- List the commands, environments, and manual checks used to verify this change. -->

- [ ] Existing automated tests pass.
- [ ] New or changed behavior has relevant automated coverage.
- [ ] UI changes were checked in supported browsers and color modes.

## Impact

<!-- Use "None" where an item does not apply. -->

- Database or migration impact:
- Configuration or deployment impact:
- API or backward-compatibility impact:
- Security impact:

## Screenshots

<!-- Include before/after images for visible UI changes, or write "Not applicable". -->

## Changelog

<!-- Added, Changed, Fixed, Removed, Deprecated, Security, or Not applicable. -->

Category:

Proposed entry:

## Checklist

- [ ] The related issue is approved and assigned to me, or a maintainer requested this work.
- [ ] Documentation was updated where behavior or configuration changed.
- [ ] No credentials, personal information, or generated build artifacts were committed.
- [ ] The change is focused and does not include unrelated formatting or refactoring.
