### PR TITLE
fix(auth): make OIDC userinfo fetch robust and discovery-aware

### DIFF
--- a/powerdnsadmin/routes/index.py
+++ b/powerdnsadmin/routes/index.py
@@ -458,11 +458,38 @@ def login():
         return authenticate_user(user, 'Azure OAuth')
 
     if 'oidc_token' in session:
-        user_data = oidc.userinfo()
-        oidc_username = user_data[Setting().get('oidc_oauth_username')]
-        oidc_first_name = user_data[Setting().get('oidc_oauth_firstname')]
-        oidc_last_name = user_data[Setting().get('oidc_oauth_last_name')]
-        oidc_email = user_data[Setting().get('oidc_oauth_email')]
+        try:
+            oidc_metadata = oidc.load_server_metadata()
+        except Exception as e:
+            current_app.logger.warning(
+                'OIDC: unable to load server metadata ({}); '
+                'falling back to relative userinfo endpoint'.format(e))
+            oidc_metadata = {}
+
+        userinfo_endpoint = oidc_metadata.get('userinfo_endpoint')
+        try:
+            if userinfo_endpoint:
+                userinfo_resp = oidc.get(userinfo_endpoint, timeout=15)
+            else:
+                userinfo_resp = oidc.get('userinfo', timeout=15)
+            userinfo_resp.raise_for_status()
+            user_data = userinfo_resp.json()
+        except Exception as e:
+            current_app.logger.error('OIDC: failed to fetch userinfo: {}'.format(e))
+            session.pop('oidc_token', None)
+            return redirect(url_for('index.login'))
+
+        oidc_username = user_data.get(Setting().get('oidc_oauth_username'))
+        oidc_first_name = user_data.get(Setting().get('oidc_oauth_firstname'), '')
+        oidc_last_name = user_data.get(Setting().get('oidc_oauth_last_name'), '')
+        oidc_email = user_data.get(Setting().get('oidc_oauth_email'), '')
+
+        if not oidc_username:
+            current_app.logger.error(
+                'OIDC: username claim "{}" not present in userinfo'.format(
+                    Setting().get('oidc_oauth_username')))
+            session.pop('oidc_token', None)
+            return redirect(url_for('index.login'))
 
         user = User.query.filter_by(username=oidc_username).first()
         if not user:


### PR DESCRIPTION
## Related issue

N/A

## Summary

`oidc.userinfo()` raised KeyError on `userinfo_endpoint` when discovery
was disabled, causing a 500 on login. Read the endpoint from server
metadata when available, fall back to the relative userinfo lookup,
add a timeout, and redirect to login on failure instead of crashing.

## Testing

<!-- List the commands, environments, and manual checks used to verify this change. -->

- [ ] Existing automated tests pass.
- [ ] New or changed behavior has relevant automated coverage.
- [ ] UI changes were checked in supported browsers and color modes.

## Impact

<!-- Use "None" where an item does not apply. -->

- Database or migration impact:
- Configuration or deployment impact:
- API or backward-compatibility impact:
- Security impact:

## Screenshots

<!-- Include before/after images for visible UI changes, or write "Not applicable". -->

## Changelog

<!-- Added, Changed, Fixed, Removed, Deprecated, Security, or Not applicable. -->

Category:

Proposed entry:

## Checklist

- [ ] The related issue is approved and assigned to me, or a maintainer requested this work.
- [ ] Documentation was updated where behavior or configuration changed.
- [ ] No credentials, personal information, or generated build artifacts were committed.
- [ ] The change is focused and does not include unrelated formatting or refactoring.
