### PR TITLE
Fix path to admin/history/history.html template

### DIFF
--- a/powerdnsadmin/routes/admin.py
+++ b/powerdnsadmin/routes/admin.py
@@ -1079,7 +1079,7 @@ def history():
                 accounts += a.name + " "
             for u in all_user_names:
                 users += u.username + " "
-        return render_template('admin/history.html', all_domain_names=doms, all_account_names=accounts,
+        return render_template('admin/history/history.html', all_domain_names=doms, all_account_names=accounts,
                                all_usernames=users)
 
 


### PR DESCRIPTION
## Related issue

Closes #1883

## Summary

A typo was made in be5cef5 and the result was the Admin -> Activity page could not load because it referenced a non-existent template file.

## Testing

- [X] Existing automated tests pass.
- [ ] New or changed behavior has relevant automated coverage.
- [X] UI changes were checked in supported browsers and color modes.

## Impact

- Database or migration impact: None
- Configuration or deployment impact: None
- API or backward-compatibility impact: None
- Security impact: None

## Screenshots

Before:  
<img width="1318" height="802" alt="Screenshot 2026-08-07 at 14 48 04" src="https://github.com/user-attachments/assets/c6b53821-fee7-4c3d-a914-90540094f741" />

After:  
<img width="1310" height="802" alt="Screenshot 2026-08-07 at 15 05 11" src="https://github.com/user-attachments/assets/aadbb4c3-b455-46a0-abb2-8fc530eb31aa" />

## Changelog

Category: Fixed

Proposed entry: "Activity" page loads once again.

## Checklist

- [ ] The related issue is approved and assigned to me, or a maintainer requested this work.
- [X] Documentation was updated where behavior or configuration changed.
- [X] No credentials, personal information, or generated build artifacts were committed.
- [X] The change is focused and does not include unrelated formatting or refactoring.
